### PR TITLE
Add Argument 2 page with navigation and clean styling

### DIFF
--- a/argument2.html
+++ b/argument2.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Argument 2: Proof of Miracles — InviteJesus</title>
+  <link rel="stylesheet" href="/assets/css/base.css"/>
+  <link rel="stylesheet" href="/assets/css/arguments.css"/>
+</head>
+<body>
+  <nav class="top-nav">
+    <a href="/">Home</a> |
+    <a href="#">7 Arguments</a> |
+    <a href="/world-religions/">World Religion Index</a> |
+    <a href="#">12 Positions</a> |
+    <a href="#">About</a>
+  </nav>
+  <main>
+    <h1>Argument 2: Proof of Miracles</h1>
+    <h2>Argument 2: A Rational Case for Prophecy and the Person of Jesus</h2>
+    <section>
+      <h3>I. Premise: Can a Divine Claim Be Tested Without Assuming One?</h3>
+      <p>Let’s begin with a simple question:
+      Is it possible to evaluate a claim of divine origin using objective methods—without first accepting religious assumptions?</p>
+      <p>You don’t need to believe the Bible is divinely inspired to consider this question. Instead, we ask:
+      What if we treat biblical texts like any other historical document and test them on their own terms?</p>
+      <p>Here’s the proposed test:
+      If a text repeatedly and accurately describes future events—beyond the scope of human foresight—should it not deserve our attention, regardless of origin?</p>
+      <p>We'll focus on a specific case:</p>
+      <ul>
+        <li>One passage: Daniel 11</li>
+        <li>One method: Probability theory</li>
+        <li>One claim: Jesus of Nazareth as the fulfillment of prophecy</li>
+      </ul>
+    </section>
+    <section>
+      <h3>II. Daniel 11: A Case Study in Predictive Specificity</h3>
+      <p>Daniel 11 is a section of Hebrew Scripture that lays out over 100 political and military events spanning roughly 365 years (from ~530 BC to 165 BC).</p>
+      <p>These predictions align remarkably with documented history—from the Persian Empire through the rise of Greece and the Seleucid-Ptolemaic conflicts.</p>
+      <p>There are only two logical possibilities:</p>
+      <ol>
+        <li>It was written before the events occurred (genuine prophecy)</li>
+        <li>It was written after the events (as historical fiction presented as prophecy)</li>
+      </ol>
+      <p>Even critical scholars agree on two points:</p>
+      <ul>
+        <li>The historical alignment is unusually precise and sustained.</li>
+        <li>If composed after the events, it is an unparalleled literary achievement in predictive detail.</li>
+      </ul>
+      <p>However, fragments of Daniel have been found among the Dead Sea Scrolls, which date to a period before some of these events occurred—complicating the late-authorship theory.</p>
+      <p>Conclusion: Daniel 11 serves as a uniquely detailed test case. If true predictive prophecy is possible, it would likely resemble this.</p>
+    </section>
+    <section>
+      <h3>III. Quantifying the Improbable: Probability Theory Meets Prophecy</h3>
+      <p>Dr. Peter Stoner, a mathematician, applied the laws of probability to biblical prophecy to determine whether fulfilled predictions could be attributed to chance.</p>
+      <p>Let’s assume—conservatively—that there was a 1 in 5 chance of predicting each event in Daniel 11 correctly (which is generous, given the geopolitical complexity involved). For 100 accurate predictions, that results in:</p>
+      <p>(1/5)<sup>100</sup> = 1 in 7.9 × 10<sup>69</sup></p>
+      <p>Under stricter assumptions (1 in 10 per event), the result becomes even more implausible:</p>
+      <p>(1/10)<sup>100</sup> = 1 in 10<sup>100</sup></p>
+      <p>These odds approach the level of statistical impossibility. The probability of such a sustained, correct sequence occurring by random chance is so low it demands an alternative explanation.</p>
+      <p>Conclusion: Either Daniel 11 is a mathematically implausible coincidence, or it reflects a source of knowledge not constrained by time.</p>
+    </section>
+    <section>
+      <h3>IV. Messianic Prophecy and the Case for Jesus</h3>
+      <p>Turning to the New Testament, we find the claim that Jesus of Nazareth fulfilled dozens of ancient prophecies, some written centuries apart.</p>
+      <p>Dr. Stoner again applied probability to this question. For just eight specific Messianic prophecies (e.g., born in Bethlehem, betrayed for 30 silver coins), he calculated:</p>
+      <p>1 in 10<sup>17</sup> (1 followed by 17 zeros)</p>
+      <p>For 48 Messianic prophecies:
+      1 in 10<sup>157</sup></p>
+      <p>These predictions were made by different authors over centuries, yet converge on a single figure in history. The probability of this being accidental becomes mathematically negligible.</p>
+      <p>Conclusion: If Daniel 11 sets the precedent that prophecy can be real, then the fulfillment of Messianic prophecy in Jesus invites serious, reasoned investigation.</p>
+    </section>
+    <section>
+      <h3>V. An Analogy of Scale: Voyager 1 and the Impossibility of Chance</h3>
+      <p>To grasp the improbability visually, consider the analogy from Stoner's original work:</p>
+      <p>Imagine covering the entire state of Texas two feet deep in silver dollars. One of them is marked. Then blindfold a person, let them wander anywhere they wish, and pick a single coin. The chance they select the marked one is roughly 1 in 10<sup>17</sup>—the same probability of Jesus fulfilling just eight prophecies by chance.</p>
+      <p>Stretching that analogy even further:
+      If you placed 10<sup>17</sup> coins edge-to-edge, the chain would stretch 2.37 trillion miles—more than 150 times the current distance of Voyager 1, the farthest human-made object in space.</p>
+      <p>This isn’t just a metaphor—it illustrates the astronomical improbability of coincidence.</p>
+    </section>
+    <section>
+      <h3>VI. Final Thought: What Do These Numbers Actually Tell Us?</h3>
+      <p>You’re not being asked to start with belief.</p>
+      <p>Instead, you're invited to examine:</p>
+      <ul>
+        <li>Daniel 11 as a historically grounded case study in predictive writing</li>
+        <li>Probability theory as an impartial tool for analysis</li>
+        <li>Messianic prophecy as a convergence of independent data points</li>
+        <li>The scale of improbability, which transcends anecdote and enters statistical law</li>
+      </ul>
+      <p>All of this leads to a reasonable, measured question:</p>
+      <p>What kind of document makes these claims—and who could be behind them?</p>
+      <p>This isn’t about blind faith. It’s about being intellectually honest in the face of unlikely precision. And that is where the deeper conversation about Jesus Christ begins.</p>
+    </section>
+    <section>
+      <h3>Selected Bibliography</h3>
+      <h4>Primary Sources</h4>
+      <p>The Bible, New International Version. Biblica, 2011.<br/>
+      (Primary text for Daniel 11 and Messianic prophecy references.)</p>
+      <h4>Statistical &amp; Prophetic Analysis</h4>
+      <p>Stoner, Peter W. <em>Science Speaks: Scientific Proof of the Accuracy of Prophecy and the Bible.</em> Moody Press, 1963.<br/>
+      (Ch. 3: "The Christ of Prophecy" contains detailed probability analysis.)</p>
+      <p>Ross, Hugh. “Probability for Fulfilled Prophecy.” Reasons to Believe, 2021.<br/>
+      <a href="https://reasons.org">https://reasons.org</a></p>
+      <h4>Historical and Theological Context</h4>
+      <p>McDowell, Josh. <em>Evidence That Demands a Verdict.</em> Thomas Nelson, 2017.</p>
+      <p>Habermas, Gary, and Licona, Michael. <em>The Case for the Resurrection of Jesus.</em> Kregel Publications, 2004.</p>
+      <p>Strobel, Lee. <em>The Case for Christ.</em> Zondervan, 1998.</p>
+      <h4>Prophetic Text Analysis</h4>
+      <p>Moeller, Mike. “Daniel 11: The Most Detailed Prophecy in the Bible.” Bible.org, 2004.<br/>
+      <a href="https://bible.org/seriespage/12-daniel-11">https://bible.org/seriespage/12-daniel-11</a></p>
+      <h4>Astronomical Scale and Voyager</h4>
+      <p>NASA Jet Propulsion Laboratory. “Where Is Voyager 1?”<br/>
+      <a href="https://voyager.jpl.nasa.gov">https://voyager.jpl.nasa.gov</a></p>
+      <p>Wikipedia Contributors. “Voyager 1.” Wikipedia: The Free Encyclopedia, August 2025 update.<br/>
+      <a href="https://en.wikipedia.org/wiki/Voyager_1">https://en.wikipedia.org/wiki/Voyager_1</a></p>
+    </section>
+  </main>
+</body>
+</html>

--- a/assets/css/arguments.css
+++ b/assets/css/arguments.css
@@ -1,0 +1,26 @@
+body {
+  margin: 0;
+  font-family: Georgia, 'Times New Roman', serif;
+  background: #e5e7eb; /* light grey */
+  color: #000;
+}
+.top-nav {
+  text-align: center;
+  padding: 0.75rem 0;
+  font-weight: 500;
+}
+.top-nav a {
+  color: inherit;
+  text-decoration: none;
+  margin: 0 0.25rem;
+}
+main {
+  max-width: 800px;
+  margin: 0 auto;
+  background: #fafafa; /* off-white */
+  padding: 2rem;
+}
+h1, h2, h3, h4, h5, h6 {
+  font-family: Georgia, 'Times New Roman', serif;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- Add dedicated Argument 2 HTML page featuring top navigation and detailed content
- Introduce arguments.css for light grey background and off-white content area with serif typography

## Testing
- `ruby build.rb`

------
https://chatgpt.com/codex/tasks/task_e_68b3ff2c548083208e65d2a7c2d0963c