### PR TITLE
Add execution report for markdown extraction scripts

### DIFF
--- a/execution_report.txt
+++ b/execution_report.txt
@@ -1,0 +1,4 @@
+extract_md_files_v1.py | success | 387 files | 179 duplicates | errors: None
+extract_md_files_v2.py | success | 387 files | 176 duplicates | errors: None
+extract_md_files_v3.py | success | 387 files | 0 duplicates | errors: None
+extract_md_files_v4.py | success | 387 files | 173 duplicates | errors: None


### PR DESCRIPTION
## Summary
- Run extraction scripts v1 through v4 on `300religions.txt`
- Record results in `execution_report.txt`

## Testing
- `python md_religions/extract_md_files_v1.py 300religions.txt -o extracted_md_files`
- `python md_religions/extract_md_files_v2.py 300religions.txt -o extracted_md_files`
- `python md_religions/extract_md_files_v3.py 300religions.txt -o extracted_md_files`
- `python md_religions/extract_md_files_v4.py 300religions.txt -o extracted_md_files`


------
https://chatgpt.com/codex/tasks/task_e_68c30c1bd7bc83209986ffabb52d6479