### PR TITLE
Add front page and 12-arguments hub centered on John 14:6

### DIFF
--- a/argument2.html
+++ b/argument2.html
@@ -4,20 +4,33 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Argument 2: Proof of Miracles — InviteJesus</title>
-  <link rel="stylesheet" href="/assets/css/base.css"/>
-  <link rel="stylesheet" href="/assets/css/arguments.css"/>
+  <meta name="description" content="A rational case for predictive prophecy and the person of Jesus, using Daniel 11 and probability theory — Argument 2 in the cumulative case for John 14:6."/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="/assets/css/site.css"/>
 </head>
 <body>
-  <nav class="top-nav">
-    <a href="/">Home</a> |
-    <a href="#">7 Arguments</a> |
-    <a href="/world-religions/">World Religion Index</a> |
-    <a href="#">12 Positions</a> |
-    <a href="#">About</a>
-  </nav>
-  <main>
+  <header class="site-nav">
+    <div class="container">
+      <a class="brand" href="/">Invite<span>Jesus</span></a>
+      <nav aria-label="Primary">
+        <ul class="nav-links">
+          <li><a href="/#mission">Mission</a></li>
+          <li><a href="/#case">The Case</a></li>
+          <li><a href="/arguments/">12 Arguments</a></li>
+          <li><a href="/religions/">World Religions</a></li>
+          <li><a href="/#about">About</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main class="article">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <a href="/">Home</a> › <a href="/arguments/">The 12 Arguments</a> › <span>Argument 2</span>
+    </nav>
     <h1>Argument 2: Proof of Miracles</h1>
-    <h2>Argument 2: A Rational Case for Prophecy and the Person of Jesus</h2>
+    <p class="deck">A Rational Case for Prophecy and the Person of Jesus</p>
     <section>
       <h3>I. Premise: Can a Divine Claim Be Tested Without Assuming One?</h3>
       <p>Let’s begin with a simple question:

--- a/arguments/index.html
+++ b/arguments/index.html
@@ -1,0 +1,188 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>The 12 Arguments — InviteJesus</title>
+  <meta name="description" content="Twelve converging apologetic arguments that together build a cumulative case for the truth of John 14:6 from an evangelical perspective."/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="/assets/css/site.css"/>
+</head>
+<body>
+  <header class="site-nav">
+    <div class="container">
+      <a class="brand" href="/">Invite<span>Jesus</span></a>
+      <nav aria-label="Primary">
+        <ul class="nav-links">
+          <li><a href="/#mission">Mission</a></li>
+          <li><a href="/#case">The Case</a></li>
+          <li><a href="/arguments/">12 Arguments</a></li>
+          <li><a href="/religions/">World Religions</a></li>
+          <li><a href="/#about">About</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container">
+        <p class="eyebrow">The cumulative case</p>
+        <blockquote class="verse">Twelve arguments for <span class="accent">one claim</span></blockquote>
+        <p class="tagline">
+          Each argument answers a question raised by the one before it. Read alone, any
+          single line of evidence can be debated. Read together, they form a converging,
+          cumulative case for the truth of John 14:6.
+        </p>
+      </div>
+    </section>
+
+    <section class="band">
+      <div class="container" style="max-width: 880px;">
+        <div class="note" style="margin-bottom: 40px;">
+          <strong>A note on this framework.</strong> The structure below is a proposed
+          organization of the twelve arguments into three movements that build on one
+          another. Titles, ordering, and groupings are a starting point meant to be
+          refined to match your own work — <em>Argument 2</em> already links to its full
+          study; the remaining entries are scaffolded and ready to be filled in.
+        </div>
+
+        <!-- MOVEMENT I -->
+        <div class="stage">
+          <div class="stage-label">
+            <span class="roman">I</span>
+            <h3>Is there a God who speaks?</h3>
+            <span class="sub">Foundations</span>
+          </div>
+          <p style="color:var(--ink-soft); margin:-6px 0 22px;">
+            Before any specific revelation can be weighed, two prior questions must be
+            faced: is there a God at all, and has that God ever acted in a way history
+            can detect?
+          </p>
+          <div class="arg-grid">
+            <a class="arg-card" id="argument-1" href="#argument-1">
+              <span class="num">Argument 1</span>
+              <h4>The Case for God's Existence</h4>
+              <p>The cosmological and contingency arguments: why something rather than nothing, and why that points to a necessary, personal cause.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" href="/argument2.html">
+              <span class="num">Argument 2</span>
+              <h4>Fulfilled Prophecy &amp; the Proof of Miracles</h4>
+              <p>Daniel 11, Messianic prophecy, and probability theory: when prediction outruns chance, a source beyond time is implied.</p>
+              <span class="status ready">Read the full study</span>
+            </a>
+          </div>
+        </div>
+
+        <!-- MOVEMENT II -->
+        <div class="stage">
+          <div class="stage-label">
+            <span class="roman">II</span>
+            <h3>Is the testimony about Jesus trustworthy?</h3>
+            <span class="sub">History &amp; Scripture</span>
+          </div>
+          <p style="color:var(--ink-soft); margin:-6px 0 22px;">
+            If God may speak, the question becomes whether the documents about Jesus are
+            historically credible, and whether their central claim — the resurrection —
+            can be reasonably affirmed.
+          </p>
+          <div class="arg-grid">
+            <a class="arg-card" id="argument-3" href="#argument-3">
+              <span class="num">Argument 3</span>
+              <h4>The Reliability of the New Testament</h4>
+              <p>Dating, manuscript evidence, and eyewitness testimony behind the Gospels.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" id="argument-4" href="#argument-4">
+              <span class="num">Argument 4</span>
+              <h4>The Resurrection of Jesus</h4>
+              <p>The minimal-facts approach and why rival theories struggle to explain them.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" id="argument-5" href="#argument-5">
+              <span class="num">Argument 5</span>
+              <h4>The Radical Claims of Jesus</h4>
+              <p>The self-understanding of Jesus and the trilemma it forces.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" id="argument-6" href="#argument-6">
+              <span class="num">Argument 6</span>
+              <h4>The Fine-Tuned Universe</h4>
+              <p>The physical constants that make life possible and what they suggest.</p>
+              <span class="status">Outline</span>
+            </a>
+          </div>
+        </div>
+
+        <!-- MOVEMENT III -->
+        <div class="stage">
+          <div class="stage-label">
+            <span class="roman">III</span>
+            <h3>Why Jesus, and not another way?</h3>
+            <span class="sub">The Verdict for John 14:6</span>
+          </div>
+          <p style="color:var(--ink-soft); margin:-6px 0 22px;">
+            With the foundations and the historical case in place, the final movement
+            confronts the exclusivity of John 14:6 directly — answering its objections
+            and setting it beside the world's alternatives.
+          </p>
+          <div class="arg-grid">
+            <a class="arg-card" id="argument-7" href="#argument-7">
+              <span class="num">Argument 7</span>
+              <h4>The Moral Law Within</h4>
+              <p>Objective morality as a signpost to a moral lawgiver.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" id="argument-8" href="#argument-8">
+              <span class="num">Argument 8</span>
+              <h4>The Problem of Evil &amp; Suffering</h4>
+              <p>The strongest objection to faith and the cross-shaped answer to it.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" id="argument-9" href="#argument-9">
+              <span class="num">Argument 9</span>
+              <h4>The Uniqueness of Grace</h4>
+              <p>How grace distinguishes the gospel from every system of human merit.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" id="argument-10" href="#argument-10">
+              <span class="num">Argument 10</span>
+              <h4>Pluralism &amp; the Question of Exclusivity</h4>
+              <p>Whether "all paths lead to God" is coherent on its own terms.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" id="argument-11" href="#argument-11">
+              <span class="num">Argument 11</span>
+              <h4>A Survey of the World's Worldviews</h4>
+              <p>The 500 traditions of the encyclopedia, read as counterpoints to the claim.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" id="argument-12" href="#argument-12">
+              <span class="num">Argument 12</span>
+              <h4>The Invitation: Answering John 14:6</h4>
+              <p>Where the cumulative case leads and the response it finally invites.</p>
+              <span class="status">Outline</span>
+            </a>
+          </div>
+        </div>
+
+        <div class="cta" style="margin-top: 8px;">
+          <h2>See the alternatives for yourself</h2>
+          <p>The case for John 14:6 is sharpest beside the worldviews it answers. Explore the encyclopedia of the world's religions.</p>
+          <a class="btn btn-primary" href="/religions/">Open the World Religion Index</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <a class="brand" href="/">Invite<span>Jesus</span></a>
+      <div>An encyclopedic study of evangelical apologetics · <a href="/arguments/">The 12 Arguments</a> · <a href="/religions/">World Religions</a></div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -1,0 +1,303 @@
+/* InviteJesus — shared site styles for the front page and arguments hub.
+   Palette: deep indigo (authority), warm gold (light/invitation), cream (paper). */
+
+:root {
+  --ink: #1b2138;
+  --ink-soft: #3c425c;
+  --muted: #6b7180;
+  --indigo: #24305e;
+  --indigo-deep: #161d3a;
+  --gold: #c89b3c;
+  --gold-soft: #e7c97a;
+  --paper: #fbf8f1;
+  --paper-card: #ffffff;
+  --line: #e7e2d6;
+  --maxw: 1080px;
+  --display: 'Cormorant Garamond', Georgia, 'Times New Roman', serif;
+  --body: 'Source Serif 4', Georgia, 'Times New Roman', serif;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  font-family: var(--body);
+  background: var(--paper);
+  color: var(--ink);
+  line-height: 1.65;
+  font-size: 18px;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1, h2, h3, h4 {
+  font-family: var(--display);
+  font-weight: 600;
+  line-height: 1.15;
+  color: var(--ink);
+}
+
+a { color: var(--indigo); }
+
+img { max-width: 100%; }
+
+.container {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ---------- Site header / nav ---------- */
+.site-nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: rgba(251, 248, 241, 0.92);
+  backdrop-filter: saturate(140%) blur(8px);
+  border-bottom: 1px solid var(--line);
+}
+.site-nav .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 64px;
+}
+.brand {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 1.5rem;
+  letter-spacing: .3px;
+  text-decoration: none;
+  color: var(--ink);
+}
+.brand span { color: var(--gold); }
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 18px;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.nav-links a {
+  text-decoration: none;
+  color: var(--ink-soft);
+  font-size: .98rem;
+  padding: 6px 2px;
+  border-bottom: 2px solid transparent;
+}
+.nav-links a:hover { color: var(--indigo); border-bottom-color: var(--gold); }
+
+/* ---------- Hero ---------- */
+.hero {
+  position: relative;
+  background:
+    radial-gradient(1200px 500px at 70% -10%, rgba(200,155,60,.22), transparent 60%),
+    linear-gradient(160deg, var(--indigo-deep), var(--indigo));
+  color: #f4f1e9;
+  padding: 92px 0 84px;
+  overflow: hidden;
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(rgba(255,255,255,.05) 1px, transparent 1px);
+  background-size: 22px 22px;
+  opacity: .5;
+  pointer-events: none;
+}
+.hero .container { position: relative; z-index: 1; max-width: 880px; text-align: center; }
+.hero .eyebrow {
+  text-transform: uppercase;
+  letter-spacing: .28em;
+  font-size: .78rem;
+  color: var(--gold-soft);
+  font-family: var(--body);
+  margin: 0 0 18px;
+}
+.verse {
+  font-family: var(--display);
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  line-height: 1.1;
+  margin: 0 auto 10px;
+  color: #fffdf7;
+  max-width: 18ch;
+}
+.verse .accent { color: var(--gold-soft); font-style: italic; }
+.verse-ref { color: #cdd2e6; letter-spacing: .12em; font-size: .85rem; text-transform: uppercase; }
+.hero p.tagline {
+  font-size: 1.18rem;
+  color: #dfe2ef;
+  max-width: 60ch;
+  margin: 26px auto 0;
+}
+.hero-actions {
+  display: flex;
+  gap: 14px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 34px;
+}
+
+/* ---------- Buttons ---------- */
+.btn {
+  display: inline-block;
+  text-decoration: none;
+  font-family: var(--body);
+  font-size: 1rem;
+  padding: 13px 26px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  transition: transform .12s ease, box-shadow .12s ease, background .12s ease;
+}
+.btn:hover { transform: translateY(-1px); }
+.btn-primary { background: var(--gold); color: #2a2102; font-weight: 600; box-shadow: 0 6px 20px rgba(200,155,60,.35); }
+.btn-primary:hover { background: var(--gold-soft); }
+.btn-ghost { background: transparent; color: #f4f1e9; border-color: rgba(255,255,255,.4); }
+.btn-ghost:hover { border-color: var(--gold-soft); color: #fffdf7; }
+
+/* ---------- Sections ---------- */
+section.band { padding: 72px 0; }
+section.band.alt { background: #f4efe3; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.section-head { max-width: 760px; margin: 0 auto 44px; text-align: center; }
+.section-head h2 { font-size: clamp(1.8rem, 3.5vw, 2.5rem); margin: 0 0 12px; }
+.section-head p { color: var(--ink-soft); font-size: 1.1rem; margin: 0; }
+.kicker {
+  text-transform: uppercase;
+  letter-spacing: .22em;
+  font-size: .76rem;
+  color: var(--gold);
+  font-family: var(--body);
+  margin: 0 0 10px;
+}
+
+/* ---------- Mission / pillars ---------- */
+.pillars { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; }
+.pillar {
+  background: var(--paper-card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 28px;
+}
+.pillar h3 { margin: 0 0 8px; font-size: 1.4rem; }
+.pillar p { margin: 0; color: var(--ink-soft); font-size: 1rem; }
+.pillar .mark { font-size: 1.6rem; color: var(--gold); }
+
+/* ---------- Cumulative case / arguments grid ---------- */
+.stage { margin-bottom: 46px; }
+.stage-label {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 10px;
+  margin-bottom: 22px;
+}
+.stage-label .roman {
+  font-family: var(--display);
+  font-size: 1.5rem;
+  color: var(--gold);
+  font-weight: 700;
+}
+.stage-label h3 { margin: 0; font-size: 1.5rem; }
+.stage-label .sub { color: var(--muted); font-size: .98rem; margin-left: auto; }
+
+.arg-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+.arg-card {
+  position: relative;
+  display: block;
+  background: var(--paper-card);
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--gold);
+  border-radius: 12px;
+  padding: 22px 24px 22px 26px;
+  text-decoration: none;
+  color: inherit;
+  transition: transform .14s ease, box-shadow .14s ease, border-color .14s ease;
+}
+.arg-card:hover { transform: translateY(-2px); box-shadow: 0 14px 30px rgba(27,33,56,.10); border-left-color: var(--indigo); }
+.arg-card .num {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--gold);
+  letter-spacing: .04em;
+}
+.arg-card h4 { margin: 4px 0 8px; font-size: 1.3rem; }
+.arg-card p { margin: 0; color: var(--ink-soft); font-size: .98rem; }
+.arg-card .status {
+  display: inline-block;
+  margin-top: 14px;
+  font-family: var(--body);
+  font-size: .72rem;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: #eef0f6;
+  color: var(--indigo);
+}
+.arg-card .status.ready { background: #e8f1e7; color: #2f6b35; }
+
+/* ---------- Note / callout ---------- */
+.note {
+  background: #fff8e6;
+  border: 1px solid #ecd9a6;
+  border-radius: 12px;
+  padding: 18px 22px;
+  color: #6a571f;
+  font-size: .98rem;
+}
+.note strong { color: #5a4815; }
+
+/* ---------- Explore / CTA ---------- */
+.cta {
+  background: linear-gradient(160deg, var(--indigo), var(--indigo-deep));
+  color: #f4f1e9;
+  border-radius: 18px;
+  padding: 54px 40px;
+  text-align: center;
+}
+.cta h2 { color: #fffdf7; font-size: clamp(1.8rem,3.5vw,2.6rem); margin: 0 0 12px; }
+.cta p { color: #dfe2ef; max-width: 56ch; margin: 0 auto 26px; }
+
+/* ---------- Footer ---------- */
+.site-footer {
+  background: var(--indigo-deep);
+  color: #c9cde0;
+  padding: 40px 0;
+  font-size: .95rem;
+}
+.site-footer a { color: var(--gold-soft); text-decoration: none; }
+.site-footer .container { display: flex; justify-content: space-between; gap: 18px; flex-wrap: wrap; align-items: center; }
+.site-footer .brand { color: #fff; }
+
+/* ---------- Article (argument pages) ---------- */
+.article { max-width: 760px; margin: 0 auto; padding: 48px 24px 72px; }
+.article .breadcrumb { font-size: .9rem; color: var(--muted); margin-bottom: 18px; }
+.article .breadcrumb a { color: var(--indigo); text-decoration: none; }
+.article h1 { font-size: clamp(2rem,4vw,2.8rem); margin: 0 0 8px; }
+.article .deck { font-size: 1.2rem; color: var(--ink-soft); margin: 0 0 28px; }
+.article section { margin: 0 0 30px; }
+.article h3 { font-size: 1.5rem; margin: 28px 0 10px; }
+.scripture {
+  border-left: 4px solid var(--gold);
+  background: #fff8e6;
+  padding: 14px 20px;
+  margin: 22px 0;
+  font-family: var(--display);
+  font-size: 1.25rem;
+  color: var(--ink);
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 820px) {
+  .pillars { grid-template-columns: 1fr; }
+  .arg-grid { grid-template-columns: 1fr; }
+  .stage-label .sub { display: none; }
+  .nav-links { gap: 2px 12px; }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,256 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>InviteJesus — The Way, the Truth, and the Life</title>
+  <meta name="description" content="An encyclopedic study of evangelical apologetics, exploring and advocating for the truth of John 14:6 — that Jesus is the way, the truth, and the life — across the world's 500 religions and worldviews."/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="/assets/css/site.css"/>
+</head>
+<body>
+  <header class="site-nav">
+    <div class="container">
+      <a class="brand" href="/">Invite<span>Jesus</span></a>
+      <nav aria-label="Primary">
+        <ul class="nav-links">
+          <li><a href="#mission">Mission</a></li>
+          <li><a href="#case">The Case</a></li>
+          <li><a href="/arguments/">12 Arguments</a></li>
+          <li><a href="/religions/">World Religions</a></li>
+          <li><a href="#about">About</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <!-- HERO -->
+    <section class="hero">
+      <div class="container">
+        <p class="eyebrow">An encyclopedic study in evangelical apologetics</p>
+        <blockquote class="verse">
+          “I am the way, <span class="accent">the truth</span>, and the life.
+          No one comes to the Father except through me.”
+        </blockquote>
+        <p class="verse-ref">John 14:6</p>
+        <p class="tagline">
+          A rigorous, respectful examination of the boldest claim ever made — tested
+          against the world's 500 religions and worldviews, and defended through twelve
+          converging lines of evidence.
+        </p>
+        <div class="hero-actions">
+          <a class="btn btn-primary" href="/arguments/">Explore the 12 Arguments</a>
+          <a class="btn btn-ghost" href="/religions/">Browse World Religions</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- MISSION -->
+    <section class="band" id="mission">
+      <div class="container">
+        <div class="section-head">
+          <p class="kicker">Our Mission</p>
+          <h2>Why this site exists</h2>
+          <p>
+            InviteJesus is not a directory of religions; it is an apologetic defense.
+            Its single aim is to show how an evangelical reading of John 14:6 could be
+            true — and why that claim deserves the careful attention of any honest seeker.
+          </p>
+        </div>
+        <div class="pillars">
+          <div class="pillar">
+            <div class="mark">✦</div>
+            <h3>Thoughtful</h3>
+            <p>
+              We engage the hardest questions on their own terms, treating the evidence
+              with the same scrutiny we would ask of any extraordinary claim.
+            </p>
+          </div>
+          <div class="pillar">
+            <div class="mark">✦</div>
+            <h3>Rigorous</h3>
+            <p>
+              History, philosophy, probability, and textual scholarship are brought to
+              bear so that faith rests on reasoned foundations, not wishful thinking.
+            </p>
+          </div>
+          <div class="pillar">
+            <div class="mark">✦</div>
+            <h3>Respectful</h3>
+            <p>
+              Every tradition is described fairly before it is examined. We persuade by
+              the weight of the case, never by caricature of those who differ.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- THE CUMULATIVE CASE -->
+    <section class="band alt" id="case">
+      <div class="container">
+        <div class="section-head">
+          <p class="kicker">A Cumulative Case</p>
+          <h2>Twelve arguments, one conclusion</h2>
+          <p>
+            No single argument stands alone. Each one answers a question the last one
+            raises, and together they accumulate into a single coherent case for the
+            truth of John 14:6. Begin anywhere — but the weight is in the whole.
+          </p>
+        </div>
+
+        <!-- Stage I -->
+        <div class="stage">
+          <div class="stage-label">
+            <span class="roman">I</span>
+            <h3>Is there a God who speaks?</h3>
+            <span class="sub">Foundations</span>
+          </div>
+          <div class="arg-grid">
+            <a class="arg-card" href="/arguments/#argument-1">
+              <span class="num">Argument 1</span>
+              <h4>The Case for God's Existence</h4>
+              <p>Before any revelation can be weighed, we ask whether a mind stands behind the universe at all.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" href="/argument2.html">
+              <span class="num">Argument 2</span>
+              <h4>Fulfilled Prophecy &amp; the Proof of Miracles</h4>
+              <p>If a text predicts history with impossible precision, it demands an explanation beyond chance.</p>
+              <span class="status ready">Read now</span>
+            </a>
+          </div>
+        </div>
+
+        <!-- Stage II -->
+        <div class="stage">
+          <div class="stage-label">
+            <span class="roman">II</span>
+            <h3>Is the testimony about Jesus trustworthy?</h3>
+            <span class="sub">History &amp; Scripture</span>
+          </div>
+          <div class="arg-grid">
+            <a class="arg-card" href="/arguments/#argument-3">
+              <span class="num">Argument 3</span>
+              <h4>The Reliability of the New Testament</h4>
+              <p>Are the Gospels early, eyewitness-anchored documents — or late legend?</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" href="/arguments/#argument-4">
+              <span class="num">Argument 4</span>
+              <h4>The Resurrection of Jesus</h4>
+              <p>The minimal historical facts and which explanation best accounts for them.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" href="/arguments/#argument-5">
+              <span class="num">Argument 5</span>
+              <h4>The Radical Claims of Jesus</h4>
+              <p>Who Jesus said he was — and why "merely a good teacher" is not an option left open.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" href="/arguments/#argument-6">
+              <span class="num">Argument 6</span>
+              <h4>The Fine-Tuned Universe</h4>
+              <p>A cosmos calibrated for life points toward intention, not accident.</p>
+              <span class="status">Outline</span>
+            </a>
+          </div>
+        </div>
+
+        <!-- Stage III -->
+        <div class="stage">
+          <div class="stage-label">
+            <span class="roman">III</span>
+            <h3>Why Jesus, and not another way?</h3>
+            <span class="sub">The Verdict for John 14:6</span>
+          </div>
+          <div class="arg-grid">
+            <a class="arg-card" href="/arguments/#argument-7">
+              <span class="num">Argument 7</span>
+              <h4>The Moral Law Within</h4>
+              <p>The reality of objective good and evil and the lawgiver it implies.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" href="/arguments/#argument-8">
+              <span class="num">Argument 8</span>
+              <h4>The Problem of Evil &amp; Suffering</h4>
+              <p>The hardest objection to faith — and the answer the cross uniquely provides.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" href="/arguments/#argument-9">
+              <span class="num">Argument 9</span>
+              <h4>The Uniqueness of Grace</h4>
+              <p>How the gospel of unearned grace differs in kind from every system of works.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" href="/arguments/#argument-10">
+              <span class="num">Argument 10</span>
+              <h4>Pluralism &amp; the Question of Exclusivity</h4>
+              <p>Whether "many paths" is as tolerant — or as coherent — as it first appears.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" href="/arguments/#argument-11">
+              <span class="num">Argument 11</span>
+              <h4>A Survey of the World's Worldviews</h4>
+              <p>500 religions and worldviews, read as the backdrop against which the claim is tested.</p>
+              <span class="status">Outline</span>
+            </a>
+            <a class="arg-card" href="/arguments/#argument-12">
+              <span class="num">Argument 12</span>
+              <h4>The Invitation: Answering John 14:6</h4>
+              <p>Where the evidence leads, and the personal response the claim finally asks for.</p>
+              <span class="status">Outline</span>
+            </a>
+          </div>
+        </div>
+
+        <div style="text-align:center; margin-top:8px;">
+          <a class="btn btn-primary" href="/arguments/">See how the arguments connect</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- WORLD RELIGIONS -->
+    <section class="band">
+      <div class="container">
+        <div class="section-head">
+          <p class="kicker">The Wider Conversation</p>
+          <h2>500 religions &amp; worldviews</h2>
+          <p>
+            Every claim is sharpest when set beside its alternatives. This growing
+            encyclopedia describes the world's faith traditions and philosophies fairly,
+            providing the context against which the case for John 14:6 is made.
+          </p>
+        </div>
+        <div style="text-align:center;">
+          <a class="btn btn-ghost" style="color:var(--indigo); border-color:var(--indigo);" href="/religions/">Open the World Religion Index</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ABOUT / CTA -->
+    <section class="band alt" id="about">
+      <div class="container">
+        <div class="cta">
+          <h2>Begin with a single question</h2>
+          <p>
+            Could the most exclusive claim in history also be the most generous
+            invitation ever offered? Follow the evidence and decide for yourself.
+          </p>
+          <a class="btn btn-primary" href="/arguments/">Start the journey</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <a class="brand" href="/">Invite<span>Jesus</span></a>
+      <div>An encyclopedic study of evangelical apologetics · <a href="/arguments/">The 12 Arguments</a> · <a href="/religions/">World Religions</a></div>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The site was missing a real front page and had no coherent place for the twelve apologetic arguments. This PR delivers both, with a cohesive visual identity, and ties the existing `argument2.html` into the new structure.

### What's new

- **`index.html` — the front page.** A mission-focused home page built around John 14:6. It opens with the verse as a hero, states the site's apologetic mission (thoughtful / rigorous / respectful), previews all twelve arguments grouped into three movements, points to the World Religion Index, and closes with an invitation/CTA.
- **`arguments/index.html` — the 12 Arguments hub.** Introduces the arguments as a *cumulative case* (each one answering a question the previous raised) organized into three movements:
  - **I. Is there a God who speaks?** — foundations
  - **II. Is the testimony about Jesus trustworthy?** — history & Scripture
  - **III. Why Jesus, and not another way?** — the verdict for John 14:6

  Argument 2 links to its full existing study; the other eleven are scaffolded with summaries and anchors, ready to be filled in. A clearly-labeled note explains the framework is a proposed starting point to be refined.
- **`assets/css/site.css` — a cohesive stylesheet.** Reverent palette (deep indigo + warm gold + cream), serif display type, sticky nav, hero, argument cards, scripture treatment, and a responsive layout.
- **`argument2.html` — reconciled.** Updated to the shared design and a consistent site nav, with breadcrumbs back to the arguments hub. The previous nav linked to dead `#` anchors and an unbuilt `/world-religions/` path; navigation now points to working routes (`/arguments/`, `/religions/`).

### Notes / decisions

- The twelve argument titles, ordering, and three-movement grouping are a **proposed framework** meant to be edited to match the owner's actual material. Argument 2 (Prophecy & Miracles) is mapped to the real existing page; the rest are placeholders with outlines.
- Navigation links to `/religions/`, which is the committed, served index, rather than the `build.rb` output dir `/world-religions/` (not committed). Reconciling the religions build is out of scope here.
- Fonts load from Google Fonts with graceful serif fallbacks; no build step is required (static GitHub Pages site).

### Verified

Served locally and confirmed `/`, `/arguments/`, `/argument2.html`, `/religions/`, and `/assets/css/site.css` all return 200.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69cdb702-9dd7-4c6e-86f4-63b62cfb7551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69cdb702-9dd7-4c6e-86f4-63b62cfb7551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

