### PR TITLE
Assign stable REL identifiers and SHA-256 hashes

### DIFF
--- a/.github/workflows/assign-religion-ids.yml
+++ b/.github/workflows/assign-religion-ids.yml
@@ -1,0 +1,40 @@
+name: Assign religion IDs and hashes
+
+on:
+  push:
+    branches:
+      - agent/assign-religion-ids
+    paths:
+      - 'scripts/assign-religion-ids.mjs'
+      - 'src/content/encyclopedia/**'
+      - '.github/workflows/assign-religion-ids.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out branch
+        uses: actions/checkout@v4
+        with:
+          ref: agent/assign-religion-ids
+          fetch-depth: 0
+
+      - name: Attribute stable REL numbers and generate SHA-256 registry
+        run: node scripts/assign-religion-ids.mjs
+
+      - name: Commit generated attribution
+        run: |
+          if git diff --quiet; then
+            echo 'Religion IDs and hashes are already current.'
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add src/content/encyclopedia src/data/religion-registry.json
+          git commit -m 'Assign REL identifiers and SHA-256 hashes'
+          git push

--- a/scripts/assign-religion-ids.mjs
+++ b/scripts/assign-religion-ids.mjs
@@ -1,0 +1,123 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve('src/content/encyclopedia');
+const REGISTRY = path.resolve('src/data/religion-registry.json');
+const ID_PATTERN = /^REL-(\d{3})$/;
+
+async function walk(directory) {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...await walk(absolute));
+    else if (entry.isFile() && entry.name.endsWith('.md')) files.push(absolute);
+  }
+
+  return files;
+}
+
+function relativePath(absolute) {
+  return path.relative(ROOT, absolute).split(path.sep).join('/');
+}
+
+function setRelId(source, relId) {
+  const newline = source.includes('\r\n') ? '\r\n' : '\n';
+  const normalized = source.replace(/\r\n/g, '\n');
+  let output;
+
+  if (normalized.startsWith('---\n')) {
+    const end = normalized.indexOf('\n---\n', 4);
+    if (end === -1) throw new Error('Unclosed YAML frontmatter');
+
+    const frontmatter = normalized.slice(4, end);
+    const body = normalized.slice(end + 5);
+    const lines = frontmatter.split('\n');
+    const index = lines.findIndex((line) => /^relId\s*:/.test(line));
+
+    if (index >= 0) lines[index] = `relId: ${relId}`;
+    else lines.unshift(`relId: ${relId}`);
+
+    output = `---\n${lines.join('\n')}\n---\n${body}`;
+  } else {
+    output = `---\nrelId: ${relId}\n---\n${normalized}`;
+  }
+
+  return newline === '\r\n' ? output.replace(/\n/g, '\r\n') : output;
+}
+
+function sha256(text) {
+  return createHash('sha256').update(Buffer.from(text, 'utf8')).digest('hex');
+}
+
+async function readExistingRegistry() {
+  try {
+    const parsed = JSON.parse(await fs.readFile(REGISTRY, 'utf8'));
+    return Array.isArray(parsed.entries) ? parsed.entries : [];
+  } catch (error) {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+const files = (await walk(ROOT)).sort((a, b) =>
+  relativePath(a).localeCompare(relativePath(b), 'en', { sensitivity: 'base' })
+);
+
+const existingEntries = await readExistingRegistry();
+const existingByPath = new Map(existingEntries.map((entry) => [entry.path, entry.id]));
+const usedNumbers = new Set();
+
+for (const id of existingByPath.values()) {
+  const match = ID_PATTERN.exec(id);
+  if (!match) throw new Error(`Invalid existing religion ID: ${id}`);
+  usedNumbers.add(Number(match[1]));
+}
+
+function nextNumber() {
+  for (let number = 1; number <= 999; number += 1) {
+    if (!usedNumbers.has(number)) {
+      usedNumbers.add(number);
+      return number;
+    }
+  }
+  throw new Error('REL namespace exhausted at REL-999');
+}
+
+const registryEntries = [];
+
+for (const file of files) {
+  const relative = relativePath(file);
+  const existingId = existingByPath.get(relative);
+  const relId = existingId ?? `REL-${String(nextNumber()).padStart(3, '0')}`;
+  const original = await fs.readFile(file, 'utf8');
+  const updated = setRelId(original, relId);
+
+  if (updated !== original) await fs.writeFile(file, updated, 'utf8');
+
+  registryEntries.push({
+    id: relId,
+    path: relative,
+    sha256: sha256(updated),
+  });
+}
+
+registryEntries.sort((a, b) => a.id.localeCompare(b.id));
+
+const registry = {
+  schemaVersion: 1,
+  namespace: 'REL',
+  hashAlgorithm: 'SHA-256',
+  hashScope: 'Exact UTF-8 bytes of each canonical Markdown file after relId attribution',
+  assignmentRule: 'Existing IDs are preserved. New IDs use the lowest unused number; the initial corpus is assigned by case-insensitive alphabetical path order.',
+  sourceDirectory: 'src/content/encyclopedia',
+  count: registryEntries.length,
+  entries: registryEntries,
+};
+
+await fs.mkdir(path.dirname(REGISTRY), { recursive: true });
+await fs.writeFile(REGISTRY, `${JSON.stringify(registry, null, 2)}\n`, 'utf8');
+
+console.log(`Attributed and hashed ${registryEntries.length} religion Markdown files.`);

--- a/src/content/encyclopedia/aboriginal-dreamtime.md
+++ b/src/content/encyclopedia/aboriginal-dreamtime.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-001
 title: "Aboriginal Dreamtime"
 slug: "aboriginal-dreamtime"
 ---

--- a/src/content/encyclopedia/aetherius-society.md
+++ b/src/content/encyclopedia/aetherius-society.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-002
 title: "Aetherius Society"
 slug: "aetherius-society"
 ---

--- a/src/content/encyclopedia/africa-folk.md
+++ b/src/content/encyclopedia/africa-folk.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-003
 title: "Africa (Traditional Religions)"
 slug: "africa-folk"
 ---

--- a/src/content/encyclopedia/africa-traditional-religions.md
+++ b/src/content/encyclopedia/africa-traditional-religions.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-004
 title: "Africa (Traditional Religions)"
 slug: "africa-traditional-religions"
 ---

--- a/src/content/encyclopedia/agnosticism.md
+++ b/src/content/encyclopedia/agnosticism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-005
 title: "Agnosticism"
 slug: "agnosticism"
 ---

--- a/src/content/encyclopedia/agon-shu.md
+++ b/src/content/encyclopedia/agon-shu.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-006
 title: "Agon Shu"
 slug: "agon-shu"
 ---

--- a/src/content/encyclopedia/ahmadiyya.md
+++ b/src/content/encyclopedia/ahmadiyya.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-007
 title: "Ahmadiyya"
 slug: "ahmadiyya"
 ---

--- a/src/content/encyclopedia/akan.md
+++ b/src/content/encyclopedia/akan.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-008
 title: "Akan"
 slug: "akan"
 ---

--- a/src/content/encyclopedia/aladura-churches.md
+++ b/src/content/encyclopedia/aladura-churches.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-009
 title: "Aladura Churches"
 slug: "aladura-churches"
 ---

--- a/src/content/encyclopedia/alawites.md
+++ b/src/content/encyclopedia/alawites.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-010
 title: "Alawites"
 slug: "alawites"
 ---

--- a/src/content/encyclopedia/americas-traditional-syncretic.md
+++ b/src/content/encyclopedia/americas-traditional-syncretic.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-011
 title: "Americas (Traditional & Syncretic)"
 slug: "americas-traditional-syncretic"
 ---

--- a/src/content/encyclopedia/ananda-marga.md
+++ b/src/content/encyclopedia/ananda-marga.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-012
 title: "Ananda Marga"
 slug: "ananda-marga"
 ---

--- a/src/content/encyclopedia/ancient-church-of-the-east.md
+++ b/src/content/encyclopedia/ancient-church-of-the-east.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-013
 title: "Ancient Church of the East"
 slug: "ancient-church-of-the-east"
 ---

--- a/src/content/encyclopedia/andean-inti.md
+++ b/src/content/encyclopedia/andean-inti.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-014
 title: "Andean Inti"
 slug: "andean-inti"
 ---

--- a/src/content/encyclopedia/andean.md
+++ b/src/content/encyclopedia/andean.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-015
 title: "Andean"
 slug: "andean"
 ---

--- a/src/content/encyclopedia/anthroposophy.md
+++ b/src/content/encyclopedia/anthroposophy.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-016
 title: "Anthroposophy"
 slug: "anthroposophy"
 ---

--- a/src/content/encyclopedia/art-of-living-foundation.md
+++ b/src/content/encyclopedia/art-of-living-foundation.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-017
 title: "Art of Living Foundation"
 slug: "art-of-living-foundation"
 ---

--- a/src/content/encyclopedia/assyrian-church-of-the-east.md
+++ b/src/content/encyclopedia/assyrian-church-of-the-east.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-018
 title: "Assyrian Church of the East"
 slug: "assyrian-church-of-the-east"
 ---

--- a/src/content/encyclopedia/atheism.md
+++ b/src/content/encyclopedia/atheism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-019
 title: "Atheism"
 slug: "atheism"
 ---

--- a/src/content/encyclopedia/aum-shinrikyo.md
+++ b/src/content/encyclopedia/aum-shinrikyo.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-020
 title: "Aum Shinrikyo"
 slug: "aum-shinrikyo"
 ---

--- a/src/content/encyclopedia/ayyavazhi.md
+++ b/src/content/encyclopedia/ayyavazhi.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-021
 title: "Ayyavazhi"
 slug: "ayyavazhi"
 ---

--- a/src/content/encyclopedia/aztec.md
+++ b/src/content/encyclopedia/aztec.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-022
 title: "Aztec"
 slug: "aztec"
 ---

--- a/src/content/encyclopedia/bahai-faith.md
+++ b/src/content/encyclopedia/bahai-faith.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-023
 title: "Bahá’í Faith"
 slug: "bahai-faith"
 ---

--- a/src/content/encyclopedia/bahai.md
+++ b/src/content/encyclopedia/bahai.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-024
 title: "Bahá’í"
 slug: "bahai"
 ---

--- a/src/content/encyclopedia/baltic-neopaganism.md
+++ b/src/content/encyclopedia/baltic-neopaganism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-025
 title: "Baltic Neopaganism (Dievturība, Romuva)"
 slug: "baltic-neopaganism"
 ---

--- a/src/content/encyclopedia/baltic-paganism.md
+++ b/src/content/encyclopedia/baltic-paganism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-026
 title: "Baltic Paganism (Dievturība, Romuva)"
 slug: "baltic-paganism"
 ---

--- a/src/content/encyclopedia/baltic.md
+++ b/src/content/encyclopedia/baltic.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-027
 title: "Baltic"
 slug: "baltic"
 ---

--- a/src/content/encyclopedia/bektashi.md
+++ b/src/content/encyclopedia/bektashi.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-028
 title: "Bektashi"
 slug: "bektashi"
 ---

--- a/src/content/encyclopedia/brahma-kumaris.md
+++ b/src/content/encyclopedia/brahma-kumaris.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-029
 title: "Brahma Kumaris"
 slug: "brahma-kumaris"
 ---

--- a/src/content/encyclopedia/buddhism.md
+++ b/src/content/encyclopedia/buddhism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-030
 title: "Buddhism"
 slug: "buddhism"
 ---

--- a/src/content/encyclopedia/builders-of-the-adytum.md
+++ b/src/content/encyclopedia/builders-of-the-adytum.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-031
 title: "Builders of the Adytum"
 slug: "builders-of-the-adytum"
 ---

--- a/src/content/encyclopedia/canaanite.md
+++ b/src/content/encyclopedia/canaanite.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-032
 title: "Canaanite"
 slug: "canaanite"
 ---

--- a/src/content/encyclopedia/candomble.md
+++ b/src/content/encyclopedia/candomble.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-033
 title: "Candomblé"
 slug: "candomble"
 ---

--- a/src/content/encyclopedia/cao-dai.md
+++ b/src/content/encyclopedia/cao-dai.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-034
 title: "Cao Dai"
 slug: "cao-dai"
 ---

--- a/src/content/encyclopedia/celtic-reconstructionism.md
+++ b/src/content/encyclopedia/celtic-reconstructionism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-035
 title: "Celtic Reconstructionism"
 slug: "celtic-reconstructionism"
 ---

--- a/src/content/encyclopedia/celtic.md
+++ b/src/content/encyclopedia/celtic.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-036
 title: "Celtic"
 slug: "celtic"
 ---

--- a/src/content/encyclopedia/chaos-magick.md
+++ b/src/content/encyclopedia/chaos-magick.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-037
 title: "Chaos Magick"
 slug: "chaos-magick"
 ---

--- a/src/content/encyclopedia/cheondoism.md
+++ b/src/content/encyclopedia/cheondoism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-038
 title: "Cheondoism"
 slug: "cheondoism"
 ---

--- a/src/content/encyclopedia/cherokee.md
+++ b/src/content/encyclopedia/cherokee.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-039
 title: "Cherokee"
 slug: "cherokee"
 ---

--- a/src/content/encyclopedia/children-of-god.md
+++ b/src/content/encyclopedia/children-of-god.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-040
 title: "Children of God (Family International)"
 slug: "children-of-god"
 ---

--- a/src/content/encyclopedia/chinese-folk-religion.md
+++ b/src/content/encyclopedia/chinese-folk-religion.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-041
 title: "Chinese Folk Religion"
 slug: "chinese-folk-religion"
 ---

--- a/src/content/encyclopedia/chishti.md
+++ b/src/content/encyclopedia/chishti.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-042
 title: "Chishti"
 slug: "chishti"
 ---

--- a/src/content/encyclopedia/christadelphians.md
+++ b/src/content/encyclopedia/christadelphians.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-043
 title: "Christadelphians"
 slug: "christadelphians"
 ---

--- a/src/content/encyclopedia/christian-science.md
+++ b/src/content/encyclopedia/christian-science.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-044
 title: "Christian Science"
 slug: "christian-science"
 ---

--- a/src/content/encyclopedia/christianity.md
+++ b/src/content/encyclopedia/christianity.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-045
 title: "Christianity"
 slug: "christianity"
 ---

--- a/src/content/encyclopedia/church-of-all-worlds.md
+++ b/src/content/encyclopedia/church-of-all-worlds.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-046
 title: "Church of All Worlds"
 slug: "church-of-all-worlds"
 ---

--- a/src/content/encyclopedia/church-of-perfect-liberty.md
+++ b/src/content/encyclopedia/church-of-perfect-liberty.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-047
 title: "Church of Perfect Liberty"
 slug: "church-of-perfect-liberty"
 ---

--- a/src/content/encyclopedia/church-of-satan.md
+++ b/src/content/encyclopedia/church-of-satan.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-048
 title: "Church of Satan (LaVeyan)"
 slug: "church-of-satan"
 ---

--- a/src/content/encyclopedia/church-of-the-subgenius.md
+++ b/src/content/encyclopedia/church-of-the-subgenius.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-049
 title: "Church of the SubGenius"
 slug: "church-of-the-subgenius"
 ---

--- a/src/content/encyclopedia/community-of-christ.md
+++ b/src/content/encyclopedia/community-of-christ.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-050
 title: "Community of Christ"
 slug: "community-of-christ"
 ---

--- a/src/content/encyclopedia/confucianism.md
+++ b/src/content/encyclopedia/confucianism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-051
 title: "Confucianism"
 slug: "confucianism"
 ---

--- a/src/content/encyclopedia/cuban-vodu.md
+++ b/src/content/encyclopedia/cuban-vodu.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-052
 title: "Cuban Vodú"
 slug: "cuban-vodu"
 ---

--- a/src/content/encyclopedia/daejonggyo.md
+++ b/src/content/encyclopedia/daejonggyo.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-053
 title: "Daejonggyo"
 slug: "daejonggyo"
 ---

--- a/src/content/encyclopedia/deism.md
+++ b/src/content/encyclopedia/deism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-054
 title: "Deism"
 slug: "deism"
 ---

--- a/src/content/encyclopedia/dinka.md
+++ b/src/content/encyclopedia/dinka.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-055
 title: "Dinka"
 slug: "dinka"
 ---

--- a/src/content/encyclopedia/discordianism.md
+++ b/src/content/encyclopedia/discordianism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-056
 title: "Discordianism"
 slug: "discordianism"
 ---

--- a/src/content/encyclopedia/divine-light-mission.md
+++ b/src/content/encyclopedia/divine-light-mission.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-057
 title: "Divine Light Mission"
 slug: "divine-light-mission"
 ---

--- a/src/content/encyclopedia/divine-science.md
+++ b/src/content/encyclopedia/divine-science.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-058
 title: "Divine Science"
 slug: "divine-science"
 ---

--- a/src/content/encyclopedia/druidry-adf.md
+++ b/src/content/encyclopedia/druidry-adf.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-059
 title: "Druidry (Ár nDraíocht Féin)"
 slug: "druidry-adf"
 ---

--- a/src/content/encyclopedia/druidry-obod.md
+++ b/src/content/encyclopedia/druidry-obod.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-060
 title: "Druidry (OBOD)"
 slug: "druidry-obod"
 ---

--- a/src/content/encyclopedia/druze.md
+++ b/src/content/encyclopedia/druze.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-061
 title: "Druze"
 slug: "druze"
 ---

--- a/src/content/encyclopedia/eckankar.md
+++ b/src/content/encyclopedia/eckankar.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-062
 title: "Eckankar"
 slug: "eckankar"
 ---

--- a/src/content/encyclopedia/egyptian.md
+++ b/src/content/encyclopedia/egyptian.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-063
 title: "Egyptian"
 slug: "egyptian"
 ---

--- a/src/content/encyclopedia/ethical-culture.md
+++ b/src/content/encyclopedia/ethical-culture.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-064
 title: "Ethical Culture"
 slug: "ethical-culture"
 ---

--- a/src/content/encyclopedia/falun-gong.md
+++ b/src/content/encyclopedia/falun-gong.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-065
 title: "Falun Gong"
 slug: "falun-gong"
 ---

--- a/src/content/encyclopedia/finnish.md
+++ b/src/content/encyclopedia/finnish.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-066
 title: "Finnish"
 slug: "finnish"
 ---

--- a/src/content/encyclopedia/flds.md
+++ b/src/content/encyclopedia/flds.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-067
 title: "Fundamentalist LDS"
 slug: "flds"
 ---

--- a/src/content/encyclopedia/gla.md
+++ b/src/content/encyclopedia/gla.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-068
 title: "God Light Association (GLA)"
 slug: "gla"
 ---

--- a/src/content/encyclopedia/gnosticism-ancient.md
+++ b/src/content/encyclopedia/gnosticism-ancient.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-069
 title: "Gnosticism (Ancient)"
 slug: "gnosticism-ancient"
 ---

--- a/src/content/encyclopedia/gnosticism.md
+++ b/src/content/encyclopedia/gnosticism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-070
 title: "Gnosticism (Modern Revivals)"
 slug: "gnosticism"
 ---

--- a/src/content/encyclopedia/god-light-association-gla.md
+++ b/src/content/encyclopedia/god-light-association-gla.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-071
 title: "God Light Association (GLA)"
 slug: "god-light-association-gla"
 ---

--- a/src/content/encyclopedia/god-light-association.md
+++ b/src/content/encyclopedia/god-light-association.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-072
 title: "God Light Association (GLA)"
 slug: "god-light-association"
 ---

--- a/src/content/encyclopedia/greek.md
+++ b/src/content/encyclopedia/greek.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-073
 title: "Greek"
 slug: "greek"
 ---

--- a/src/content/encyclopedia/haitian-vodou.md
+++ b/src/content/encyclopedia/haitian-vodou.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-074
 title: "Haitian Vodou"
 slug: "haitian-vodou"
 ---

--- a/src/content/encyclopedia/happy-science.md
+++ b/src/content/encyclopedia/happy-science.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-075
 title: "Happy Science"
 slug: "happy-science"
 ---

--- a/src/content/encyclopedia/hawaiian.md
+++ b/src/content/encyclopedia/hawaiian.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-076
 title: "Hawaiian"
 slug: "hawaiian"
 ---

--- a/src/content/encyclopedia/heathenry-asatru.md
+++ b/src/content/encyclopedia/heathenry-asatru.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-077
 title: "Heathenry (Ásatrú)"
 slug: "heathenry-asatru"
 ---

--- a/src/content/encyclopedia/heathenry-troth.md
+++ b/src/content/encyclopedia/heathenry-troth.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-078
 title: "Heathenry (The Troth)"
 slug: "heathenry-troth"
 ---

--- a/src/content/encyclopedia/heavens-gate.md
+++ b/src/content/encyclopedia/heavens-gate.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-079
 title: "Heaven’s Gate"
 slug: "heavens-gate"
 ---

--- a/src/content/encyclopedia/hellenism-reconstructionist.md
+++ b/src/content/encyclopedia/hellenism-reconstructionist.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-080
 title: "Hellenism (Reconstructionist)"
 slug: "hellenism-reconstructionist"
 ---

--- a/src/content/encyclopedia/hellenism.md
+++ b/src/content/encyclopedia/hellenism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-081
 title: "Hellenism (Greek Revival)"
 slug: "hellenism"
 ---

--- a/src/content/encyclopedia/hermetic-order-of-the-golden-dawn.md
+++ b/src/content/encyclopedia/hermetic-order-of-the-golden-dawn.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-082
 title: "Hermetic Order of the Golden Dawn"
 slug: "hermetic-order-of-the-golden-dawn"
 ---

--- a/src/content/encyclopedia/hermeticism.md
+++ b/src/content/encyclopedia/hermeticism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-083
 title: "Hermeticism"
 slug: "hermeticism"
 ---

--- a/src/content/encyclopedia/hinduism.md
+++ b/src/content/encyclopedia/hinduism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-084
 title: "Hinduism"
 slug: "hinduism"
 ---

--- a/src/content/encyclopedia/hopi.md
+++ b/src/content/encyclopedia/hopi.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-085
 title: "Hopi"
 slug: "hopi"
 ---

--- a/src/content/encyclopedia/humanism.md
+++ b/src/content/encyclopedia/humanism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-086
 title: "Humanism"
 slug: "humanism"
 ---

--- a/src/content/encyclopedia/i-am-movement.md
+++ b/src/content/encyclopedia/i-am-movement.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-087
 title: "I AM Movement"
 slug: "i-am-movement"
 ---

--- a/src/content/encyclopedia/ifa.md
+++ b/src/content/encyclopedia/ifa.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-088
 title: "Ifá"
 slug: "ifa"
 ---

--- a/src/content/encyclopedia/independent-catholic.md
+++ b/src/content/encyclopedia/independent-catholic.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-089
 title: "Independent Catholic"
 slug: "independent-catholic"
 ---

--- a/src/content/encyclopedia/indigenous-folk-traditions.md
+++ b/src/content/encyclopedia/indigenous-folk-traditions.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-090
 title: "Indigenous & Folk Traditions"
 slug: "indigenous-folk-traditions"
 ---

--- a/src/content/encyclopedia/integral-yoga.md
+++ b/src/content/encyclopedia/integral-yoga.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-091
 title: "Integral Yoga"
 slug: "integral-yoga"
 ---

--- a/src/content/encyclopedia/iskcon-hare-krishna.md
+++ b/src/content/encyclopedia/iskcon-hare-krishna.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-092
 title: "ISKCON/Hare Krishna"
 slug: "iskcon-hare-krishna"
 ---

--- a/src/content/encyclopedia/islam.md
+++ b/src/content/encyclopedia/islam.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-093
 title: "Islam"
 slug: "islam"
 ---

--- a/src/content/encyclopedia/jainism.md
+++ b/src/content/encyclopedia/jainism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-094
 title: "Jainism"
 slug: "jainism"
 ---

--- a/src/content/encyclopedia/jehovahs-witnesses.md
+++ b/src/content/encyclopedia/jehovahs-witnesses.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-095
 title: "Jehovah’s Witnesses"
 slug: "jehovahs-witnesses"
 ---

--- a/src/content/encyclopedia/john-frum.md
+++ b/src/content/encyclopedia/john-frum.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-096
 title: "John Frum"
 slug: "john-frum"
 ---

--- a/src/content/encyclopedia/judaism.md
+++ b/src/content/encyclopedia/judaism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-097
 title: "Judaism"
 slug: "judaism"
 ---

--- a/src/content/encyclopedia/kemeticism.md
+++ b/src/content/encyclopedia/kemeticism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-098
 title: "Kemeticism"
 slug: "kemeticism"
 ---

--- a/src/content/encyclopedia/kimbanguism.md
+++ b/src/content/encyclopedia/kimbanguism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-099
 title: "Kimbanguism"
 slug: "kimbanguism"
 ---

--- a/src/content/encyclopedia/lakota-sun-dance.md
+++ b/src/content/encyclopedia/lakota-sun-dance.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-100
 title: "Lakota Sun Dance"
 slug: "lakota-sun-dance"
 ---

--- a/src/content/encyclopedia/lakota-vision-quest.md
+++ b/src/content/encyclopedia/lakota-vision-quest.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-101
 title: "Lakota Vision Quest"
 slug: "lakota-vision-quest"
 ---

--- a/src/content/encyclopedia/lakota.md
+++ b/src/content/encyclopedia/lakota.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-102
 title: "Lakota"
 slug: "lakota"
 ---

--- a/src/content/encyclopedia/lds-mormons.md
+++ b/src/content/encyclopedia/lds-mormons.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-103
 title: "LDS/Mormons"
 slug: "lds-mormons"
 ---

--- a/src/content/encyclopedia/lingayatism.md
+++ b/src/content/encyclopedia/lingayatism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-104
 title: "Lingayatism"
 slug: "lingayatism"
 ---

--- a/src/content/encyclopedia/luciferianism.md
+++ b/src/content/encyclopedia/luciferianism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-105
 title: "Luciferianism"
 slug: "luciferianism"
 ---

--- a/src/content/encyclopedia/maasai.md
+++ b/src/content/encyclopedia/maasai.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-106
 title: "Maasai Religion"
 slug: "maasai"
 ---

--- a/src/content/encyclopedia/mahikari.md
+++ b/src/content/encyclopedia/mahikari.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-107
 title: "Mahikari"
 slug: "mahikari"
 ---

--- a/src/content/encyclopedia/mandaeism.md
+++ b/src/content/encyclopedia/mandaeism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-108
 title: "Mandaeism"
 slug: "mandaeism"
 ---

--- a/src/content/encyclopedia/manichaeism.md
+++ b/src/content/encyclopedia/manichaeism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-109
 title: "Manichaeism"
 slug: "manichaeism"
 ---

--- a/src/content/encyclopedia/maori.md
+++ b/src/content/encyclopedia/maori.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-110
 title: "Māori"
 slug: "maori"
 ---

--- a/src/content/encyclopedia/mapuche.md
+++ b/src/content/encyclopedia/mapuche.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-111
 title: "Mapuche"
 slug: "mapuche"
 ---

--- a/src/content/encyclopedia/maya.md
+++ b/src/content/encyclopedia/maya.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-112
 title: "Maya"
 slug: "maya"
 ---

--- a/src/content/encyclopedia/meher-baba-movement.md
+++ b/src/content/encyclopedia/meher-baba-movement.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-113
 title: "Meher Baba Movement"
 slug: "meher-baba-movement"
 ---

--- a/src/content/encyclopedia/meher-baba.md
+++ b/src/content/encyclopedia/meher-baba.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-114
 title: "Meher Baba Movement"
 slug: "meher-baba"
 ---

--- a/src/content/encyclopedia/mesopotamian.md
+++ b/src/content/encyclopedia/mesopotamian.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-115
 title: "Mesopotamian"
 slug: "mesopotamian"
 ---

--- a/src/content/encyclopedia/mevlevi.md
+++ b/src/content/encyclopedia/mevlevi.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-116
 title: "Mevlevi"
 slug: "mevlevi"
 ---

--- a/src/content/encyclopedia/mithraism.md
+++ b/src/content/encyclopedia/mithraism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-117
 title: "Mithraism"
 slug: "mithraism"
 ---

--- a/src/content/encyclopedia/naqshbandi.md
+++ b/src/content/encyclopedia/naqshbandi.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-118
 title: "Naqshbandi"
 slug: "naqshbandi"
 ---

--- a/src/content/encyclopedia/nation-of-islam.md
+++ b/src/content/encyclopedia/nation-of-islam.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-119
 title: "Nation of Islam"
 slug: "nation-of-islam"
 ---

--- a/src/content/encyclopedia/nation-of-yahweh.md
+++ b/src/content/encyclopedia/nation-of-yahweh.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-120
 title: "Nation of Yahweh"
 slug: "nation-of-yahweh"
 ---

--- a/src/content/encyclopedia/native-american-church.md
+++ b/src/content/encyclopedia/native-american-church.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-121
 title: "Native American Church"
 slug: "native-american-church"
 ---

--- a/src/content/encyclopedia/native-american-religions.md
+++ b/src/content/encyclopedia/native-american-religions.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-122
 title: "Native American Religions"
 slug: "native-american-religions"
 ---

--- a/src/content/encyclopedia/navajo.md
+++ b/src/content/encyclopedia/navajo.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-123
 title: "Navajo"
 slug: "navajo"
 ---

--- a/src/content/encyclopedia/neo-druidry.md
+++ b/src/content/encyclopedia/neo-druidry.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-124
 title: "Neo-Druidry"
 slug: "neo-druidry"
 ---

--- a/src/content/encyclopedia/new-thought.md
+++ b/src/content/encyclopedia/new-thought.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-125
 title: "New Thought"
 slug: "new-thought"
 ---

--- a/src/content/encyclopedia/nichiren-shoshu-soka-gakkai.md
+++ b/src/content/encyclopedia/nichiren-shoshu-soka-gakkai.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-126
 title: "Nichiren Shōshū/Soka Gakkai"
 slug: "nichiren-shoshu-soka-gakkai"
 ---

--- a/src/content/encyclopedia/nimatullahi.md
+++ b/src/content/encyclopedia/nimatullahi.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-127
 title: "Ni’matullahi"
 slug: "nimatullahi"
 ---

--- a/src/content/encyclopedia/norse.md
+++ b/src/content/encyclopedia/norse.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-128
 title: "Norse"
 slug: "norse"
 ---

--- a/src/content/encyclopedia/objectivism.md
+++ b/src/content/encyclopedia/objectivism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-129
 title: "Objectivism"
 slug: "objectivism"
 ---

--- a/src/content/encyclopedia/old-catholic.md
+++ b/src/content/encyclopedia/old-catholic.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-130
 title: "Old Catholic"
 slug: "old-catholic"
 ---

--- a/src/content/encyclopedia/olmec.md
+++ b/src/content/encyclopedia/olmec.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-131
 title: "Olmec"
 slug: "olmec"
 ---

--- a/src/content/encyclopedia/oneness-pentecostals.md
+++ b/src/content/encyclopedia/oneness-pentecostals.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-132
 title: "Oneness Pentecostals"
 slug: "oneness-pentecostals"
 ---

--- a/src/content/encyclopedia/onmyodo.md
+++ b/src/content/encyclopedia/onmyodo.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-133
 title: "Onmyōdō"
 slug: "onmyodo"
 ---

--- a/src/content/encyclopedia/oomoto.md
+++ b/src/content/encyclopedia/oomoto.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-134
 title: "Oomoto"
 slug: "oomoto"
 ---

--- a/src/content/encyclopedia/ordo-templi-orientis.md
+++ b/src/content/encyclopedia/ordo-templi-orientis.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-135
 title: "Ordo Templi Orientis"
 slug: "ordo-templi-orientis"
 ---

--- a/src/content/encyclopedia/osho-rajneesh-movement.md
+++ b/src/content/encyclopedia/osho-rajneesh-movement.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-136
 title: "Osho/Rajneesh Movement"
 slug: "osho-rajneesh-movement"
 ---

--- a/src/content/encyclopedia/pachamama.md
+++ b/src/content/encyclopedia/pachamama.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-137
 title: "Pachamama"
 slug: "pachamama"
 ---

--- a/src/content/encyclopedia/pacific-islander-faiths.md
+++ b/src/content/encyclopedia/pacific-islander-faiths.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-138
 title: "Pacific Islander Traditional Religions"
 slug: "pacific-islander-faiths"
 ---

--- a/src/content/encyclopedia/pacific-oceanic.md
+++ b/src/content/encyclopedia/pacific-oceanic.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-139
 title: "Pacific & Oceanic"
 slug: "pacific-oceanic"
 ---

--- a/src/content/encyclopedia/paliau.md
+++ b/src/content/encyclopedia/paliau.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-140
 title: "Paliau"
 slug: "paliau"
 ---

--- a/src/content/encyclopedia/pantheism.md
+++ b/src/content/encyclopedia/pantheism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-141
 title: "Pantheism"
 slug: "pantheism"
 ---

--- a/src/content/encyclopedia/plymouth-brethren.md
+++ b/src/content/encyclopedia/plymouth-brethren.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-142
 title: "Plymouth Brethren"
 slug: "plymouth-brethren"
 ---

--- a/src/content/encyclopedia/polynesian-traditions.md
+++ b/src/content/encyclopedia/polynesian-traditions.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-143
 title: "Polynesian Traditions"
 slug: "polynesian-traditions"
 ---

--- a/src/content/encyclopedia/process-church-of-the-final-judgment.md
+++ b/src/content/encyclopedia/process-church-of-the-final-judgment.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-144
 title: "Process Church of the Final Judgment"
 slug: "process-church-of-the-final-judgment"
 ---

--- a/src/content/encyclopedia/qadiriyya.md
+++ b/src/content/encyclopedia/qadiriyya.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-145
 title: "Qadiriyya"
 slug: "qadiriyya"
 ---

--- a/src/content/encyclopedia/quakers.md
+++ b/src/content/encyclopedia/quakers.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-146
 title: "Quakers (Religious Society of Friends)"
 slug: "quakers"
 ---

--- a/src/content/encyclopedia/quimbanda.md
+++ b/src/content/encyclopedia/quimbanda.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-147
 title: "Quimbanda"
 slug: "quimbanda"
 ---

--- a/src/content/encyclopedia/raelism.md
+++ b/src/content/encyclopedia/raelism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-148
 title: "Raëlism"
 slug: "raelism"
 ---

--- a/src/content/encyclopedia/rajneesh-osho.md
+++ b/src/content/encyclopedia/rajneesh-osho.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-149
 title: "Rajneesh/Osho"
 slug: "rajneesh-osho"
 ---

--- a/src/content/encyclopedia/ramakrishna-mission.md
+++ b/src/content/encyclopedia/ramakrishna-mission.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-150
 title: "Ramakrishna Mission"
 slug: "ramakrishna-mission"
 ---

--- a/src/content/encyclopedia/rastafarianism.md
+++ b/src/content/encyclopedia/rastafarianism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-151
 title: "Rastafarianism"
 slug: "rastafarianism"
 ---

--- a/src/content/encyclopedia/religious-science.md
+++ b/src/content/encyclopedia/religious-science.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-152
 title: "Religious Science"
 slug: "religious-science"
 ---

--- a/src/content/encyclopedia/remnant-lds.md
+++ b/src/content/encyclopedia/remnant-lds.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-153
 title: "Remnant Church of Jesus Christ"
 slug: "remnant-lds"
 ---

--- a/src/content/encyclopedia/rodnovery.md
+++ b/src/content/encyclopedia/rodnovery.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-154
 title: "Rodnovery"
 slug: "rodnovery"
 ---

--- a/src/content/encyclopedia/roman-reconstructionism.md
+++ b/src/content/encyclopedia/roman-reconstructionism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-155
 title: "Roman Reconstructionism"
 slug: "roman-reconstructionism"
 ---

--- a/src/content/encyclopedia/roman.md
+++ b/src/content/encyclopedia/roman.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-156
 title: "Roman"
 slug: "roman"
 ---

--- a/src/content/encyclopedia/ryukyuan-religion.md
+++ b/src/content/encyclopedia/ryukyuan-religion.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-157
 title: "Ryukyuan Religion"
 slug: "ryukyuan-religion"
 ---

--- a/src/content/encyclopedia/sahaja-yoga.md
+++ b/src/content/encyclopedia/sahaja-yoga.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-158
 title: "Sahaja Yoga"
 slug: "sahaja-yoga"
 ---

--- a/src/content/encyclopedia/sai-baba-movement.md
+++ b/src/content/encyclopedia/sai-baba-movement.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-159
 title: "Sathya Sai Baba Movement"
 slug: "sai-baba-movement"
 ---

--- a/src/content/encyclopedia/samaritanism.md
+++ b/src/content/encyclopedia/samaritanism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-160
 title: "Samaritanism"
 slug: "samaritanism"
 ---

--- a/src/content/encyclopedia/san-khoisan.md
+++ b/src/content/encyclopedia/san-khoisan.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-161
 title: "San/Khoisan Traditional Beliefs"
 slug: "san-khoisan"
 ---

--- a/src/content/encyclopedia/san.md
+++ b/src/content/encyclopedia/san.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-162
 title: "San"
 slug: "san"
 ---

--- a/src/content/encyclopedia/sant-mat.md
+++ b/src/content/encyclopedia/sant-mat.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-163
 title: "Sant Mat"
 slug: "sant-mat"
 ---

--- a/src/content/encyclopedia/santeria.md
+++ b/src/content/encyclopedia/santeria.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-164
 title: "Santería"
 slug: "santeria"
 ---

--- a/src/content/encyclopedia/santhal-tribal.md
+++ b/src/content/encyclopedia/santhal-tribal.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-165
 title: "Santhal & Tribal (Northeast India)"
 slug: "santhal-tribal"
 ---

--- a/src/content/encyclopedia/santo-daime.md
+++ b/src/content/encyclopedia/santo-daime.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-166
 title: "Santo Daime"
 slug: "santo-daime"
 ---

--- a/src/content/encyclopedia/satanic-temple.md
+++ b/src/content/encyclopedia/satanic-temple.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-167
 title: "Satanic Temple"
 slug: "satanic-temple"
 ---

--- a/src/content/encyclopedia/satanism.md
+++ b/src/content/encyclopedia/satanism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-168
 title: "Satanism"
 slug: "satanism"
 ---

--- a/src/content/encyclopedia/sathya-sai-baba-movement.md
+++ b/src/content/encyclopedia/sathya-sai-baba-movement.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-169
 title: "Sathya Sai Baba Movement"
 slug: "sathya-sai-baba-movement"
 ---

--- a/src/content/encyclopedia/sathya-sai-baba.md
+++ b/src/content/encyclopedia/sathya-sai-baba.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-170
 title: "Sathya Sai Baba Movement"
 slug: "sathya-sai-baba"
 ---

--- a/src/content/encyclopedia/scientology.md
+++ b/src/content/encyclopedia/scientology.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-171
 title: "Scientology"
 slug: "scientology"
 ---

--- a/src/content/encyclopedia/secular-humanism.md
+++ b/src/content/encyclopedia/secular-humanism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-172
 title: "Secular Humanism"
 slug: "secular-humanism"
 ---

--- a/src/content/encyclopedia/secular.md
+++ b/src/content/encyclopedia/secular.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-173
 title: "Secular/Philosophical"
 slug: "secular"
 ---

--- a/src/content/encyclopedia/seicho-no-ie.md
+++ b/src/content/encyclopedia/seicho-no-ie.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-174
 title: "Seicho-No-Ie"
 slug: "seicho-no-ie"
 ---

--- a/src/content/encyclopedia/sekai-kyusei-kyo.md
+++ b/src/content/encyclopedia/sekai-kyusei-kyo.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-175
 title: "Sekai Kyusei Kyo"
 slug: "sekai-kyusei-kyo"
 ---

--- a/src/content/encyclopedia/self-realization-fellowship.md
+++ b/src/content/encyclopedia/self-realization-fellowship.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-176
 title: "Self-Realization Fellowship"
 slug: "self-realization-fellowship"
 ---

--- a/src/content/encyclopedia/serer.md
+++ b/src/content/encyclopedia/serer.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-177
 title: "Serer"
 slug: "serer"
 ---

--- a/src/content/encyclopedia/shakers.md
+++ b/src/content/encyclopedia/shakers.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-178
 title: "Shakers"
 slug: "shakers"
 ---

--- a/src/content/encyclopedia/shinnyo-en.md
+++ b/src/content/encyclopedia/shinnyo-en.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-179
 title: "Shinnyo-en"
 slug: "shinnyo-en"
 ---

--- a/src/content/encyclopedia/shinto.md
+++ b/src/content/encyclopedia/shinto.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-180
 title: "Shinto"
 slug: "shinto"
 ---

--- a/src/content/encyclopedia/sikhism.md
+++ b/src/content/encyclopedia/sikhism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-181
 title: "Sikhism"
 slug: "sikhism"
 ---

--- a/src/content/encyclopedia/slavic.md
+++ b/src/content/encyclopedia/slavic.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-182
 title: "Slavic"
 slug: "slavic"
 ---

--- a/src/content/encyclopedia/srf.md
+++ b/src/content/encyclopedia/srf.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-183
 title: "Self-Realization Fellowship"
 slug: "srf"
 ---

--- a/src/content/encyclopedia/summit-lighthouse.md
+++ b/src/content/encyclopedia/summit-lighthouse.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-184
 title: "Summit Lighthouse"
 slug: "summit-lighthouse"
 ---

--- a/src/content/encyclopedia/swedenborgianism.md
+++ b/src/content/encyclopedia/swedenborgianism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-185
 title: "Swedenborgianism"
 slug: "swedenborgianism"
 ---

--- a/src/content/encyclopedia/swedenborgians.md
+++ b/src/content/encyclopedia/swedenborgians.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-186
 title: "Swedenborgians"
 slug: "swedenborgians"
 ---

--- a/src/content/encyclopedia/taoism.md
+++ b/src/content/encyclopedia/taoism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-187
 title: "Taoism"
 slug: "taoism"
 ---

--- a/src/content/encyclopedia/temple-of-set.md
+++ b/src/content/encyclopedia/temple-of-set.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-188
 title: "Temple of Set"
 slug: "temple-of-set"
 ---

--- a/src/content/encyclopedia/temple-of-the-vampire.md
+++ b/src/content/encyclopedia/temple-of-the-vampire.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-189
 title: "Temple of the Vampire"
 slug: "temple-of-the-vampire"
 ---

--- a/src/content/encyclopedia/tenrikyo.md
+++ b/src/content/encyclopedia/tenrikyo.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-190
 title: "Tenrikyo"
 slug: "tenrikyo"
 ---

--- a/src/content/encyclopedia/theistic-satanism.md
+++ b/src/content/encyclopedia/theistic-satanism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-191
 title: "Theistic Satanism"
 slug: "theistic-satanism"
 ---

--- a/src/content/encyclopedia/thelema.md
+++ b/src/content/encyclopedia/thelema.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-192
 title: "Thelema"
 slug: "thelema"
 ---

--- a/src/content/encyclopedia/theosophy.md
+++ b/src/content/encyclopedia/theosophy.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-193
 title: "Theosophy"
 slug: "theosophy"
 ---

--- a/src/content/encyclopedia/toltec.md
+++ b/src/content/encyclopedia/toltec.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-194
 title: "Toltec"
 slug: "toltec"
 ---

--- a/src/content/encyclopedia/transcendental-meditation.md
+++ b/src/content/encyclopedia/transcendental-meditation.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-195
 title: "Transcendental Meditation"
 slug: "transcendental-meditation"
 ---

--- a/src/content/encyclopedia/umbanda.md
+++ b/src/content/encyclopedia/umbanda.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-196
 title: "Umbanda"
 slug: "umbanda"
 ---

--- a/src/content/encyclopedia/uniao-do-vegetal.md
+++ b/src/content/encyclopedia/uniao-do-vegetal.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-197
 title: "União do Vegetal"
 slug: "uniao-do-vegetal"
 ---

--- a/src/content/encyclopedia/unification-church.md
+++ b/src/content/encyclopedia/unification-church.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-198
 title: "Unification Church"
 slug: "unification-church"
 ---

--- a/src/content/encyclopedia/unity-church.md
+++ b/src/content/encyclopedia/unity-church.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-199
 title: "Unity Church"
 slug: "unity-church"
 ---

--- a/src/content/encyclopedia/universal-medicine.md
+++ b/src/content/encyclopedia/universal-medicine.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-200
 title: "Universal Medicine"
 slug: "universal-medicine"
 ---

--- a/src/content/encyclopedia/vedanta-society.md
+++ b/src/content/encyclopedia/vedanta-society.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-201
 title: "Vedanta Society"
 slug: "vedanta-society"
 ---

--- a/src/content/encyclopedia/vodou.md
+++ b/src/content/encyclopedia/vodou.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-202
 title: "Vodou"
 slug: "vodou"
 ---

--- a/src/content/encyclopedia/vodun.md
+++ b/src/content/encyclopedia/vodun.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-203
 title: "Vodun (West Africa)"
 slug: "vodun"
 ---

--- a/src/content/encyclopedia/wicca-alexandrian.md
+++ b/src/content/encyclopedia/wicca-alexandrian.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-204
 title: "Wicca (Alexandrian)"
 slug: "wicca-alexandrian"
 ---

--- a/src/content/encyclopedia/wicca-dianic.md
+++ b/src/content/encyclopedia/wicca-dianic.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-205
 title: "Wicca (Dianic)"
 slug: "wicca-dianic"
 ---

--- a/src/content/encyclopedia/wicca-eclectic.md
+++ b/src/content/encyclopedia/wicca-eclectic.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-206
 title: "Wicca (Eclectic)"
 slug: "wicca-eclectic"
 ---

--- a/src/content/encyclopedia/wicca-gardnerian.md
+++ b/src/content/encyclopedia/wicca-gardnerian.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-207
 title: "Wicca (Gardnerian)"
 slug: "wicca-gardnerian"
 ---

--- a/src/content/encyclopedia/wicca.md
+++ b/src/content/encyclopedia/wicca.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-208
 title: "Wicca"
 slug: "wicca"
 ---

--- a/src/content/encyclopedia/won-buddhism.md
+++ b/src/content/encyclopedia/won-buddhism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-209
 title: "Won Buddhism"
 slug: "won-buddhism"
 ---

--- a/src/content/encyclopedia/yali.md
+++ b/src/content/encyclopedia/yali.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-210
 title: "Yali"
 slug: "yali"
 ---

--- a/src/content/encyclopedia/yazidism.md
+++ b/src/content/encyclopedia/yazidism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-211
 title: "Yazidism"
 slug: "yazidism"
 ---

--- a/src/content/encyclopedia/yoruba.md
+++ b/src/content/encyclopedia/yoruba.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-212
 title: "Yoruba"
 slug: "yoruba"
 ---

--- a/src/content/encyclopedia/zapotec.md
+++ b/src/content/encyclopedia/zapotec.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-213
 title: "Zapotec"
 slug: "zapotec"
 ---

--- a/src/content/encyclopedia/zion-christian-church.md
+++ b/src/content/encyclopedia/zion-christian-church.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-214
 title: "Zion Christian Church"
 slug: "zion-christian-church"
 ---

--- a/src/content/encyclopedia/zoroastrianism.md
+++ b/src/content/encyclopedia/zoroastrianism.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-215
 title: "Zoroastrianism"
 slug: "zoroastrianism"
 ---

--- a/src/content/encyclopedia/zulu.md
+++ b/src/content/encyclopedia/zulu.md
@@ -1,4 +1,5 @@
 ---
+relId: REL-216
 title: "Zulu"
 slug: "zulu"
 ---

--- a/src/data/religion-registry.json
+++ b/src/data/religion-registry.json
@@ -1,0 +1,1091 @@
+{
+  "schemaVersion": 1,
+  "namespace": "REL",
+  "hashAlgorithm": "SHA-256",
+  "hashScope": "Exact UTF-8 bytes of each canonical Markdown file after relId attribution",
+  "assignmentRule": "Existing IDs are preserved. New IDs use the lowest unused number; the initial corpus is assigned by case-insensitive alphabetical path order.",
+  "sourceDirectory": "src/content/encyclopedia",
+  "count": 216,
+  "entries": [
+    {
+      "id": "REL-001",
+      "path": "aboriginal-dreamtime.md",
+      "sha256": "e72ce54607c7ad7c3a21b8e93b3c13eaa156ce61e2503e526f96b3a0daed2b73"
+    },
+    {
+      "id": "REL-002",
+      "path": "aetherius-society.md",
+      "sha256": "b10b37e9bc3e5347a68b9ad9c0eb604d2de9e1fab2a26c4a6a0706d6a26769b0"
+    },
+    {
+      "id": "REL-003",
+      "path": "africa-folk.md",
+      "sha256": "287040b83ca7304fae18e17ec09134fde252feee920f6acfd3d513570523dc64"
+    },
+    {
+      "id": "REL-004",
+      "path": "africa-traditional-religions.md",
+      "sha256": "90f03fb395b875c4ec92fab9e653e0482309254f3a89b99ebda0fe6ea7fa5577"
+    },
+    {
+      "id": "REL-005",
+      "path": "agnosticism.md",
+      "sha256": "2b10aa572de800a65bdc9ea90d5ad3df0e160ccbf20bd0f1ccd862e422e3b5a7"
+    },
+    {
+      "id": "REL-006",
+      "path": "agon-shu.md",
+      "sha256": "b163605d3e1595eb87a5206ef8b11c476c532486cd161f4ca29819f88afc1390"
+    },
+    {
+      "id": "REL-007",
+      "path": "ahmadiyya.md",
+      "sha256": "14841b5b54fb73f25bddb7649b1770ecc82c53fb5d87f3fda8e615e63e899db4"
+    },
+    {
+      "id": "REL-008",
+      "path": "akan.md",
+      "sha256": "2dc811b8194a6e1c8a0ecb926569949dc64f9d5e160619b0ae7a2ecf28452790"
+    },
+    {
+      "id": "REL-009",
+      "path": "aladura-churches.md",
+      "sha256": "b418d1ae3352d31779bf7bfdffa29d899e2a8ffc98bc753bd1679ed8732b59b7"
+    },
+    {
+      "id": "REL-010",
+      "path": "alawites.md",
+      "sha256": "a9c0979c460b5db791c1492ed0a273a27c48f8e5e2bd4850f48fb003e6b42e57"
+    },
+    {
+      "id": "REL-011",
+      "path": "americas-traditional-syncretic.md",
+      "sha256": "3c070702177427c5bec1241673f871baea99311468b6d4fe67607ee4a13151c5"
+    },
+    {
+      "id": "REL-012",
+      "path": "ananda-marga.md",
+      "sha256": "0231de080e38f158f75c33be196dcac9e1851132a4a78fa032d64bc0366ec9d7"
+    },
+    {
+      "id": "REL-013",
+      "path": "ancient-church-of-the-east.md",
+      "sha256": "31e7c75d8041be9d8b31b3d869e9103b1402f08a998acd3944fdcd0f4bd0adbd"
+    },
+    {
+      "id": "REL-014",
+      "path": "andean-inti.md",
+      "sha256": "857abfef2937b7928623802918c8ca07956da0791c6eb70edc04bc197352068b"
+    },
+    {
+      "id": "REL-015",
+      "path": "andean.md",
+      "sha256": "d043b14769c3a7b7b6a06aa4116e7c4122e27fdbbb2c5ab2536e2bc8314b9a70"
+    },
+    {
+      "id": "REL-016",
+      "path": "anthroposophy.md",
+      "sha256": "84b498f78b1e3be1a60cddc5b3f01651e138acb08a0e5bcfdbd90cdfd2286682"
+    },
+    {
+      "id": "REL-017",
+      "path": "art-of-living-foundation.md",
+      "sha256": "e5e5f23c7dfc394530ae2cc1a54f37c62eee6b714222df38f2ee2ae91b5d22f9"
+    },
+    {
+      "id": "REL-018",
+      "path": "assyrian-church-of-the-east.md",
+      "sha256": "6b6d1f43a772f0dff4807726f17812a733a14114b09e3f179894a470609a1fdf"
+    },
+    {
+      "id": "REL-019",
+      "path": "atheism.md",
+      "sha256": "9c341f4eda1dddbf8caf87c2f25fcab3c538e9662388cffa8c37168890696113"
+    },
+    {
+      "id": "REL-020",
+      "path": "aum-shinrikyo.md",
+      "sha256": "984f1d3721e155dd4e9c2c8923d95ca603db1685bf951a941c4b0835086397a2"
+    },
+    {
+      "id": "REL-021",
+      "path": "ayyavazhi.md",
+      "sha256": "7f3af8a9d755bd6a5ba60fd9249a18b9f09593a0efd313a705a7b366275f0dbe"
+    },
+    {
+      "id": "REL-022",
+      "path": "aztec.md",
+      "sha256": "1cd67a25a4931e43b14b8cd485de0f85c451275d8308e6efdf630c6287d1b583"
+    },
+    {
+      "id": "REL-023",
+      "path": "bahai-faith.md",
+      "sha256": "e06d3d1b6f3abc702bbba0465bc97afa34a43742befde5a6c88a58b073d884ae"
+    },
+    {
+      "id": "REL-024",
+      "path": "bahai.md",
+      "sha256": "f57fa8c10d43fb0983de23aee6288c40975851c72cdf16c128a128867890236e"
+    },
+    {
+      "id": "REL-025",
+      "path": "baltic-neopaganism.md",
+      "sha256": "2fba7ede8133baed7baa524195d4a92c7e187ca1893711f7a0f2e2941e7b4181"
+    },
+    {
+      "id": "REL-026",
+      "path": "baltic-paganism.md",
+      "sha256": "9bc01815ae51bac6e2a4dc0dcd41c1557d04af8a46c023515391d271033c26d5"
+    },
+    {
+      "id": "REL-027",
+      "path": "baltic.md",
+      "sha256": "29e58c08debf44ac69ed77ba9abb3978490432f550375a0f77328eac39bdb671"
+    },
+    {
+      "id": "REL-028",
+      "path": "bektashi.md",
+      "sha256": "546205bad0a1b6f6518143563150f0cd8b61ec336bc11ba4c8b08ce868e62578"
+    },
+    {
+      "id": "REL-029",
+      "path": "brahma-kumaris.md",
+      "sha256": "af9a7425ffbd9d0525be7eecbea91b65276677f8f00d24a72f310bd90f8ab4fd"
+    },
+    {
+      "id": "REL-030",
+      "path": "buddhism.md",
+      "sha256": "2593850cd0b83c495d46f6ff3a48246307ef5448db430b8219717adf837d4608"
+    },
+    {
+      "id": "REL-031",
+      "path": "builders-of-the-adytum.md",
+      "sha256": "b7b11c741fb77558fe8573f4ad2aeddcbf781186579b567ec401363ce56c608e"
+    },
+    {
+      "id": "REL-032",
+      "path": "canaanite.md",
+      "sha256": "75885c5a1e584eebcfdd258282a743742c67cff7e540d806f3d1ac733e128205"
+    },
+    {
+      "id": "REL-033",
+      "path": "candomble.md",
+      "sha256": "f4e8b37cb4b5a34ec71520fca8f48452d4b0c0db24c3c5255619ad9d524cb286"
+    },
+    {
+      "id": "REL-034",
+      "path": "cao-dai.md",
+      "sha256": "709a2fefe1053e1cf02ad02bf9708b2485fd4e92c356101cbaa9efd64c9d76ce"
+    },
+    {
+      "id": "REL-035",
+      "path": "celtic-reconstructionism.md",
+      "sha256": "f03e83a8861dd5edd0152232e1dba853445b9243a9b53519706b2294fa8c0dc3"
+    },
+    {
+      "id": "REL-036",
+      "path": "celtic.md",
+      "sha256": "42e325e51cdee0943b1138bb50c9a97eff3e0798162066dc74afdee7f8835700"
+    },
+    {
+      "id": "REL-037",
+      "path": "chaos-magick.md",
+      "sha256": "5c64e912dc5e5d4a522800a628ce9f85c4d48cf0f8f17ce26d64f7feaa153e02"
+    },
+    {
+      "id": "REL-038",
+      "path": "cheondoism.md",
+      "sha256": "3362faa51d7d091aed4904a704984820b1fe4bb62b2757a9d9522f230bec46a1"
+    },
+    {
+      "id": "REL-039",
+      "path": "cherokee.md",
+      "sha256": "9cde9d3d01c2e1fa5ab6607a00dec9253a118be6520a73de0db4641ecb352ae7"
+    },
+    {
+      "id": "REL-040",
+      "path": "children-of-god.md",
+      "sha256": "007b018418236e6c7381c3f8dbaaf38fcb6fb2306141afe2d1bef37f6aa2c36d"
+    },
+    {
+      "id": "REL-041",
+      "path": "chinese-folk-religion.md",
+      "sha256": "1b85642328e338a6a73fa0045bd08c7905c616086442e2be877e64c3ea2c3c64"
+    },
+    {
+      "id": "REL-042",
+      "path": "chishti.md",
+      "sha256": "03703312a1d374fd1d6151e5c1b43b2473f19b9b802f5b7fc863e1e18bfbfc9e"
+    },
+    {
+      "id": "REL-043",
+      "path": "christadelphians.md",
+      "sha256": "9dc3b185a6a503ecf07c6799843fa38b2f90c0faa184f4556b600f170dee9595"
+    },
+    {
+      "id": "REL-044",
+      "path": "christian-science.md",
+      "sha256": "ff9cf813e48fe9847ce48d27eb682f199b61c43020ca4b3c86fc4c934534807f"
+    },
+    {
+      "id": "REL-045",
+      "path": "christianity.md",
+      "sha256": "c8f617a05b2f3307cf3deb5d3bc42f7289a6bcc0b0dc591bc0de3da33dcb8e4b"
+    },
+    {
+      "id": "REL-046",
+      "path": "church-of-all-worlds.md",
+      "sha256": "2779b9bfd4440e448bec7aa2a6cef5a651381a59d923e11b8c7b94f8bdd346af"
+    },
+    {
+      "id": "REL-047",
+      "path": "church-of-perfect-liberty.md",
+      "sha256": "49271e93584bf0204340c04ea6e885fb86077ea45e1448ac73278d5620595b85"
+    },
+    {
+      "id": "REL-048",
+      "path": "church-of-satan.md",
+      "sha256": "2d26923c7bf0e3c39ef8d0303aa3d0a00bbc25043cdd3ca11ffeb2eefad75a8f"
+    },
+    {
+      "id": "REL-049",
+      "path": "church-of-the-subgenius.md",
+      "sha256": "2988eb0344e6a84f6946e6ba60ea58c67c6cadd9434c81d11e30a0b9a7938aa4"
+    },
+    {
+      "id": "REL-050",
+      "path": "community-of-christ.md",
+      "sha256": "e84a3c6b0d3025e1774ea163319256077a74a63e5d80ec42d1637cbfa5995301"
+    },
+    {
+      "id": "REL-051",
+      "path": "confucianism.md",
+      "sha256": "90b78fb08f2704fca40989a1d7fd6961330d07c7a455e4519ef9d40d801efd50"
+    },
+    {
+      "id": "REL-052",
+      "path": "cuban-vodu.md",
+      "sha256": "aea24115d8a76aa04cd6fac497b134d80205fecea370d329ba68202556b25a2a"
+    },
+    {
+      "id": "REL-053",
+      "path": "daejonggyo.md",
+      "sha256": "bce0954d7c57190dbf4432bcf2ac18323ebbd9886e62f285b2d82ddefcd97ae0"
+    },
+    {
+      "id": "REL-054",
+      "path": "deism.md",
+      "sha256": "a30bc0e60c10afc5a2d2a36840cf399f9cd9c89d84e7fa09343b85ba6000d2f1"
+    },
+    {
+      "id": "REL-055",
+      "path": "dinka.md",
+      "sha256": "f7808d19c4d839cfd4fea0c9d601b2220c32929a0b4d4200abdddbcdc83786ab"
+    },
+    {
+      "id": "REL-056",
+      "path": "discordianism.md",
+      "sha256": "40de4c5a889a9b03c3ea657841c2518e8f3a111def151c8b0dcea62fc1552efd"
+    },
+    {
+      "id": "REL-057",
+      "path": "divine-light-mission.md",
+      "sha256": "54bea92b51d0c91048fbcd656353f8ad19642dd0fde83b816f6e5f6069eb1425"
+    },
+    {
+      "id": "REL-058",
+      "path": "divine-science.md",
+      "sha256": "f0bf16dadfdfce3a5e995abc7a2b6f2db059cfbc6733f24ffbbe26b2ab8a871a"
+    },
+    {
+      "id": "REL-059",
+      "path": "druidry-adf.md",
+      "sha256": "fed46b732c52cb7affeace45b1295afc16d67c7625a39d948527647aff7804a5"
+    },
+    {
+      "id": "REL-060",
+      "path": "druidry-obod.md",
+      "sha256": "53508898dbb98d3965a9ca369be9d82194436fe3c4faeb5fdf91afc56e4ba776"
+    },
+    {
+      "id": "REL-061",
+      "path": "druze.md",
+      "sha256": "7b3a1c4f0bfe278a0c08ce8c495a8b10fed71ee04b58802a132e08638aada2d2"
+    },
+    {
+      "id": "REL-062",
+      "path": "eckankar.md",
+      "sha256": "39cb7d947ea06d2d491ad383f0cda46bfe3c12bd202f22096b9c20a902368ac1"
+    },
+    {
+      "id": "REL-063",
+      "path": "egyptian.md",
+      "sha256": "e8a7a907d002afa7f7ff3118e61e1e636a686274a181af8dee14a900f368c301"
+    },
+    {
+      "id": "REL-064",
+      "path": "ethical-culture.md",
+      "sha256": "b81d2bbc3b5fb2eefaeb22077927f83f232db35676b3b10b8fcbc0a71eadef05"
+    },
+    {
+      "id": "REL-065",
+      "path": "falun-gong.md",
+      "sha256": "7e1f1ea4f447f6a769cf17f9b28ddde24a9d5dfe2d048ced9d59819d8abccc64"
+    },
+    {
+      "id": "REL-066",
+      "path": "finnish.md",
+      "sha256": "48dff0a7a6e96be4bf0e3984b8859e4ec685e8fcb65a68225bb49e642bfff542"
+    },
+    {
+      "id": "REL-067",
+      "path": "flds.md",
+      "sha256": "e303a9570ac27898153f56cbd0f046906a4c1d4f9658f45d0fb16939653f2991"
+    },
+    {
+      "id": "REL-068",
+      "path": "gla.md",
+      "sha256": "ff56389ae97e94a395a5260f2c3a8f1e60776369db7646db232220168d53ae21"
+    },
+    {
+      "id": "REL-069",
+      "path": "gnosticism-ancient.md",
+      "sha256": "9bae5f77d8bebfb1f53eecd81d9cf2bad7ab9cac21ce40ad2e334ea15acffe84"
+    },
+    {
+      "id": "REL-070",
+      "path": "gnosticism.md",
+      "sha256": "1cb52611108d085b22426432677aefb2ef12d5fd8296d8e7de4e65cc1f722a82"
+    },
+    {
+      "id": "REL-071",
+      "path": "god-light-association-gla.md",
+      "sha256": "638e91bd5ef9264df018d4768a8423c883abf2893e756e7f68c9ead5501e2ff5"
+    },
+    {
+      "id": "REL-072",
+      "path": "god-light-association.md",
+      "sha256": "a5bb3a8ea006e28b9b28804ca3efe13dc5638e99378dd9e2d50543d6cd1ea438"
+    },
+    {
+      "id": "REL-073",
+      "path": "greek.md",
+      "sha256": "ae6b47bc9de67e3b93b11bebb408e1d11bf6f46acb6f00553b66ff9779f6ce7d"
+    },
+    {
+      "id": "REL-074",
+      "path": "haitian-vodou.md",
+      "sha256": "7ca6012076e9e651b72103fe2a178db576bdf76daa2355a7ed158037010fd2cb"
+    },
+    {
+      "id": "REL-075",
+      "path": "happy-science.md",
+      "sha256": "fcae438d0220973fa3740fadaf7a7d60b113936b5d6133391e706cf2531fa77e"
+    },
+    {
+      "id": "REL-076",
+      "path": "hawaiian.md",
+      "sha256": "90db77c9f478a0adbaf69962d53d02e045e0f1c3014b3b1b53a069b3a4cbed7d"
+    },
+    {
+      "id": "REL-077",
+      "path": "heathenry-asatru.md",
+      "sha256": "124559a5cc0c9c54497fd8e55ba0117d1948af3b481897544139d3b3f4da513a"
+    },
+    {
+      "id": "REL-078",
+      "path": "heathenry-troth.md",
+      "sha256": "d1eb4167f33e93f81d9eb90e45c01d54d082db4df6980a7e6414eebf0e82c7eb"
+    },
+    {
+      "id": "REL-079",
+      "path": "heavens-gate.md",
+      "sha256": "e6c9b256ad6ec6fa7289c799a1c14cf23d351fb1da2a39a51235bd896535136b"
+    },
+    {
+      "id": "REL-080",
+      "path": "hellenism-reconstructionist.md",
+      "sha256": "32ec3e622dfa02df46541508410d8a9d1d532ee99f3fe51a278daa95fdf5f61b"
+    },
+    {
+      "id": "REL-081",
+      "path": "hellenism.md",
+      "sha256": "dd7d8a60fb14b2250a59c5a3c578c625a0b1ef1ba1817e4f42787d1c3f3b3001"
+    },
+    {
+      "id": "REL-082",
+      "path": "hermetic-order-of-the-golden-dawn.md",
+      "sha256": "dfef9c153c34c3e65052194d7eceaddba6d3a930b9b914af94f3ab8373ce7303"
+    },
+    {
+      "id": "REL-083",
+      "path": "hermeticism.md",
+      "sha256": "9d167491fe1f512060a3ea06d1231f492dac84b6bb83e120c6c4e09d9dad0095"
+    },
+    {
+      "id": "REL-084",
+      "path": "hinduism.md",
+      "sha256": "4f8c25afca8f4f62854f0e5778f0253f7e2a0291eab654be36843434664b3e7f"
+    },
+    {
+      "id": "REL-085",
+      "path": "hopi.md",
+      "sha256": "77792b475c8c99250c87d0b9fdea90f212a41e30c7fc55d83f7fb8d75ab8c63f"
+    },
+    {
+      "id": "REL-086",
+      "path": "humanism.md",
+      "sha256": "3a74311df06f78737f73a6ac7749e488d6178d6367af6669b81460535482e917"
+    },
+    {
+      "id": "REL-087",
+      "path": "i-am-movement.md",
+      "sha256": "d4de672b602069fb9973ee975c1f3201fb8d62916b1334fb149c877ba1209ebe"
+    },
+    {
+      "id": "REL-088",
+      "path": "ifa.md",
+      "sha256": "0fe9c417eaded8d957763066f4449afcf6d20157211c7cde225b5bd5e6f9ab25"
+    },
+    {
+      "id": "REL-089",
+      "path": "independent-catholic.md",
+      "sha256": "654558180eece239d7e9c7887949bc1d9a6e79038918b520a9054084bd2ff717"
+    },
+    {
+      "id": "REL-090",
+      "path": "indigenous-folk-traditions.md",
+      "sha256": "ee1c3a4a8a161b2b303dd09de664eee8241a88e8718c535e3dc7d84970e1ef13"
+    },
+    {
+      "id": "REL-091",
+      "path": "integral-yoga.md",
+      "sha256": "b1827141e548d1d5177b614898b68504ef927f97058e73b3602fb4f0faa4873e"
+    },
+    {
+      "id": "REL-092",
+      "path": "iskcon-hare-krishna.md",
+      "sha256": "bbfb20f3e060de602e094213761daab0c862c22d19980c9b414fb5be61712c39"
+    },
+    {
+      "id": "REL-093",
+      "path": "islam.md",
+      "sha256": "37672c8d4187a6bb7c76af5e72f9838c293c37fba255cd036aebbeffbde949aa"
+    },
+    {
+      "id": "REL-094",
+      "path": "jainism.md",
+      "sha256": "b7541d82a2d33e90f66cb13fa531ad6fb2aada0a6e1489a229d5ce390cc37b31"
+    },
+    {
+      "id": "REL-095",
+      "path": "jehovahs-witnesses.md",
+      "sha256": "15783bf83db30d262d51db0aa2d5089c874a2ea7520017f36ea115c880c6adcb"
+    },
+    {
+      "id": "REL-096",
+      "path": "john-frum.md",
+      "sha256": "39d94b2d09db495767d2cba16645c9a76ccb9fdfb6b95c6e82fea4779895a8ca"
+    },
+    {
+      "id": "REL-097",
+      "path": "judaism.md",
+      "sha256": "0a3ae2823a5f7937f68f8c8ddc189ef87bc771c48abb01775d4589626796e3e9"
+    },
+    {
+      "id": "REL-098",
+      "path": "kemeticism.md",
+      "sha256": "7260e82304e63583e99abcefd977b7e82f828dd16041526a6de6eadb77e7bc58"
+    },
+    {
+      "id": "REL-099",
+      "path": "kimbanguism.md",
+      "sha256": "43d0e45c5716895711e55c1bd9f1d1f185a7b00119f788d3a88b91eb27d0a364"
+    },
+    {
+      "id": "REL-100",
+      "path": "lakota-sun-dance.md",
+      "sha256": "47f392143e97b3762dd625cce6cf97069d69d612d116d85f63810c937c08fe0b"
+    },
+    {
+      "id": "REL-101",
+      "path": "lakota-vision-quest.md",
+      "sha256": "3fe2e3b323dee45bd144a93f60a1b9d62b4969444e34e899e2712edaf8aa3028"
+    },
+    {
+      "id": "REL-102",
+      "path": "lakota.md",
+      "sha256": "1ba94a5d382204d46f6d3d5c610c5040f1fadef693f2dd80f7dfa2f98b927f2f"
+    },
+    {
+      "id": "REL-103",
+      "path": "lds-mormons.md",
+      "sha256": "bc31b0b34afd207155bfff53d720c37c494abf83032ffae19ccb458e81cd3c7a"
+    },
+    {
+      "id": "REL-104",
+      "path": "lingayatism.md",
+      "sha256": "0f788884f3a8a57d15cecaf6cb6ddfc0909698d535babe12aa3626da66a7867e"
+    },
+    {
+      "id": "REL-105",
+      "path": "luciferianism.md",
+      "sha256": "fe97ec9f0ed6424da910ff5d5bbbaf4ed58f1722cda60d0e5427bc39143a4294"
+    },
+    {
+      "id": "REL-106",
+      "path": "maasai.md",
+      "sha256": "0b865d24976b80daa48e8a92e4f628ccc5dc23316146dffbf4f0ac99e8893d28"
+    },
+    {
+      "id": "REL-107",
+      "path": "mahikari.md",
+      "sha256": "7a1c970e0dd57b7af2d1e03bfb8d600586fc3a6f0136f1c00606db33978f5b8c"
+    },
+    {
+      "id": "REL-108",
+      "path": "mandaeism.md",
+      "sha256": "d34463e4b6e52128bb3151d2df62493255019a7cc8d9b23d4780f98ba457f78b"
+    },
+    {
+      "id": "REL-109",
+      "path": "manichaeism.md",
+      "sha256": "7c275024fd9a0cae0cc09d3a3f21b79eea9e94655494ee72589a16fa0f9e1f99"
+    },
+    {
+      "id": "REL-110",
+      "path": "maori.md",
+      "sha256": "c1d5d23f814f52f9579eb9c80a3661d8e68a5bbfa3ac1119ba61e479e199ff9b"
+    },
+    {
+      "id": "REL-111",
+      "path": "mapuche.md",
+      "sha256": "8699df968c18a8737c00e2696e09cdc15f5f6f701513a0d0e7850f3f7191b130"
+    },
+    {
+      "id": "REL-112",
+      "path": "maya.md",
+      "sha256": "289a0fd3c03527f1ec0e8357ba62a6a1c08ab2f3731c08f5481a054a85c34306"
+    },
+    {
+      "id": "REL-113",
+      "path": "meher-baba-movement.md",
+      "sha256": "7bf630da233005901fae1ee6a5dadac1646e9b473afe38c724a8c5592d82fc6d"
+    },
+    {
+      "id": "REL-114",
+      "path": "meher-baba.md",
+      "sha256": "9b859cd142c91bf7ac3bb964133e7daf2b820d7e82b6d9620df68cc3d5dd3869"
+    },
+    {
+      "id": "REL-115",
+      "path": "mesopotamian.md",
+      "sha256": "4d73e833b6fafbb69821ccc8e2f107912ec4f074b4d5b5e9373489c75576df8d"
+    },
+    {
+      "id": "REL-116",
+      "path": "mevlevi.md",
+      "sha256": "ca3b0461fbb34c48f04ef2f2207386c2b84a1042164cedddb0a863f089eb7fbb"
+    },
+    {
+      "id": "REL-117",
+      "path": "mithraism.md",
+      "sha256": "1de07919ed15ee93c189fc5991bd8533f734f0c0dd9415311c0a0a07e2199be2"
+    },
+    {
+      "id": "REL-118",
+      "path": "naqshbandi.md",
+      "sha256": "3a69f0828117f0d1ff7205ab1ad6ad6ae5f05bc2cdec75f148819b3ab33d040f"
+    },
+    {
+      "id": "REL-119",
+      "path": "nation-of-islam.md",
+      "sha256": "0b819872f08d1cbe8c0c9322a2b5b979b1d100b19c017babbd49ebd0d999c467"
+    },
+    {
+      "id": "REL-120",
+      "path": "nation-of-yahweh.md",
+      "sha256": "faaafb54cf12c9c22af341164a813e30054a7fe82ae08b503fd48fdcd80ea7aa"
+    },
+    {
+      "id": "REL-121",
+      "path": "native-american-church.md",
+      "sha256": "7b3287455d7eb8777cf2fb23cec158be15f32ce7389325d49be4929574b9d8c0"
+    },
+    {
+      "id": "REL-122",
+      "path": "native-american-religions.md",
+      "sha256": "2229e58357de7c623e3daf688ded9450bd441d3896766e0f17eacb8f7509d3e2"
+    },
+    {
+      "id": "REL-123",
+      "path": "navajo.md",
+      "sha256": "a7354df310c96cf4339edef5237b513053941a65c1b4fc61eef78362d9196966"
+    },
+    {
+      "id": "REL-124",
+      "path": "neo-druidry.md",
+      "sha256": "3a7a1a4c452dc3b1c5043b46ff99c7432794ce5bedf4441518bdeff0be9cbe84"
+    },
+    {
+      "id": "REL-125",
+      "path": "new-thought.md",
+      "sha256": "4b138018bfbeae6115e25f7b1f0c017f6bc4a8342709da90273046a0c1abce18"
+    },
+    {
+      "id": "REL-126",
+      "path": "nichiren-shoshu-soka-gakkai.md",
+      "sha256": "64869fe844beb3677859d77dfb59c2ad8032b0abe92cc2c302620534c3cdf13d"
+    },
+    {
+      "id": "REL-127",
+      "path": "nimatullahi.md",
+      "sha256": "0aabdd11f48946e14011fd71de508c2d9dc3279e9c1273c48484899d935e18f9"
+    },
+    {
+      "id": "REL-128",
+      "path": "norse.md",
+      "sha256": "6ba890e943af225424d5fe3977fd5788733658df4b277b9db82a47891d19b138"
+    },
+    {
+      "id": "REL-129",
+      "path": "objectivism.md",
+      "sha256": "0536998a020aed7cc8babdecfeb77cb2e614e0fde3e183371f859405a70307b5"
+    },
+    {
+      "id": "REL-130",
+      "path": "old-catholic.md",
+      "sha256": "2d9ff8b0b46034058c042ce974aa873b479c3d464c90db8c97dca02688fe120b"
+    },
+    {
+      "id": "REL-131",
+      "path": "olmec.md",
+      "sha256": "0a40660e7a3094ff6ea33d475b1343add25c06df53be5c737551a3ad504ab4af"
+    },
+    {
+      "id": "REL-132",
+      "path": "oneness-pentecostals.md",
+      "sha256": "f3d5fdbdefccd777e8bdb10eb5be356bedbd58d3012332571406beaed35b6ba2"
+    },
+    {
+      "id": "REL-133",
+      "path": "onmyodo.md",
+      "sha256": "5d3f1b13266d093dfd8dcc52759839b9990479bb85a197f6dbc9a626dcb608ab"
+    },
+    {
+      "id": "REL-134",
+      "path": "oomoto.md",
+      "sha256": "4af936150279f70b457e945a30ec7089adcb9c8ff5ae3b33ed3adc3971002f77"
+    },
+    {
+      "id": "REL-135",
+      "path": "ordo-templi-orientis.md",
+      "sha256": "e4b476cad733bba6a1cd926e07cba3a2e56ec0514d37a6b2923aa119876ec23b"
+    },
+    {
+      "id": "REL-136",
+      "path": "osho-rajneesh-movement.md",
+      "sha256": "a73671101b9a0d20b3c3151c2c94e92d1cc1991af9228860aa038588d064ae6f"
+    },
+    {
+      "id": "REL-137",
+      "path": "pachamama.md",
+      "sha256": "3ecf324e2c30049c8a56a5d3d8e1cb0e720190e6aa1bf8cfbb325a0367348454"
+    },
+    {
+      "id": "REL-138",
+      "path": "pacific-islander-faiths.md",
+      "sha256": "410fd9a6b9c6056066c62c0bf0ff6097f9cf450cae84616e60849262a4797ec4"
+    },
+    {
+      "id": "REL-139",
+      "path": "pacific-oceanic.md",
+      "sha256": "cd4641ec0b0e4c5086182bcbc21abe2a08df1d3c37b41c01cdd1531ed4d9f6ba"
+    },
+    {
+      "id": "REL-140",
+      "path": "paliau.md",
+      "sha256": "94420c66604074f658314e935d605b19e7aa7eefe9630a411ae883a153bf29a8"
+    },
+    {
+      "id": "REL-141",
+      "path": "pantheism.md",
+      "sha256": "c1a6a1d67bcd17a2fb50b8ccbf9897bdab87c95d21c3a0733137675e436cdaf8"
+    },
+    {
+      "id": "REL-142",
+      "path": "plymouth-brethren.md",
+      "sha256": "cacc013e036724b2293b7d8b29a2321b6e6b98b16f6f16e1672241ed71d0c03f"
+    },
+    {
+      "id": "REL-143",
+      "path": "polynesian-traditions.md",
+      "sha256": "dd2debb0a92a452ea1857c68fe02bc3390963657a6a6d9bfa60bf438f9b8a113"
+    },
+    {
+      "id": "REL-144",
+      "path": "process-church-of-the-final-judgment.md",
+      "sha256": "fa7f4cf111fe02332b461b04f1407d56c7efb060592dd4d164e91b0d44d35fa4"
+    },
+    {
+      "id": "REL-145",
+      "path": "qadiriyya.md",
+      "sha256": "2299458435f4fbe3fd11986be159c2cc7f193175ce89483dd198d3932aa67945"
+    },
+    {
+      "id": "REL-146",
+      "path": "quakers.md",
+      "sha256": "38f1e5370978d305305747e6c317a98c2a54562676c76914734397edfeed23a5"
+    },
+    {
+      "id": "REL-147",
+      "path": "quimbanda.md",
+      "sha256": "242a25e940a99eb0781efbce1d2fe6296c10425372636200696ed36095d91dec"
+    },
+    {
+      "id": "REL-148",
+      "path": "raelism.md",
+      "sha256": "0794f8a460b7927f075ddd9ab45f838e8fbfb51a9d72bb2785e974c85e5d69a1"
+    },
+    {
+      "id": "REL-149",
+      "path": "rajneesh-osho.md",
+      "sha256": "5fe3b708a6104800b0419dc7731ca07385260a0a1e01d04b9011697fc10fecbf"
+    },
+    {
+      "id": "REL-150",
+      "path": "ramakrishna-mission.md",
+      "sha256": "19517182aeef11f75daa363ef0ebbb15012a67d7590bd18c31a72f2274567a82"
+    },
+    {
+      "id": "REL-151",
+      "path": "rastafarianism.md",
+      "sha256": "b95d89afb850fdeed7a9f8cc2701874e432b8911dc8fe840f2a7fe6f63ea6b7c"
+    },
+    {
+      "id": "REL-152",
+      "path": "religious-science.md",
+      "sha256": "03ff395a2fc4981224b31feaecdbddf0e3a2496b2d445b0c1daa5c15f714e894"
+    },
+    {
+      "id": "REL-153",
+      "path": "remnant-lds.md",
+      "sha256": "3fa74e887c34fd9bf1043a81327a686ec721b3a8dd54c890ab60a11bfcea9824"
+    },
+    {
+      "id": "REL-154",
+      "path": "rodnovery.md",
+      "sha256": "4fba35f759070816a771349e4a7a75a0e194208b67c255815cc3dfc6e130cbf7"
+    },
+    {
+      "id": "REL-155",
+      "path": "roman-reconstructionism.md",
+      "sha256": "e311b8cdeaaed66f1ed3425806be1d4bce0434d6312b1f897487501de5c174f5"
+    },
+    {
+      "id": "REL-156",
+      "path": "roman.md",
+      "sha256": "d373c99de5a78ceaeefd68254a4c51e4adee6ad458729cf82802ed9dd77fe9fa"
+    },
+    {
+      "id": "REL-157",
+      "path": "ryukyuan-religion.md",
+      "sha256": "f4cf0ba539b7b43bd3daf701ca308f437363e332194b11b98d68ad0846e4c646"
+    },
+    {
+      "id": "REL-158",
+      "path": "sahaja-yoga.md",
+      "sha256": "05a20ddfd27f0b21eacd42a04cb730fcc73493215e475c4fcb33028ff961f7b6"
+    },
+    {
+      "id": "REL-159",
+      "path": "sai-baba-movement.md",
+      "sha256": "48b3adb3c548ef2de8281f5119270a880eb6b403cb8148aefdcdbfafb545c1f2"
+    },
+    {
+      "id": "REL-160",
+      "path": "samaritanism.md",
+      "sha256": "11470bb1cff9a77f9b828c74bc13dd7830f07397d7a86722cf6925a6fa286455"
+    },
+    {
+      "id": "REL-161",
+      "path": "san-khoisan.md",
+      "sha256": "6512ee7ba5e846e17dbe294a6104babd951e262612ebb8f62da27ce6e2468261"
+    },
+    {
+      "id": "REL-162",
+      "path": "san.md",
+      "sha256": "5d0222b53312d0a675d62e83e903c12ac34354133d8a5391fea6b09cfac47f47"
+    },
+    {
+      "id": "REL-163",
+      "path": "sant-mat.md",
+      "sha256": "d9af4e5d5c7073acb7042df032aa9c3dc079619752cb0ae2b80cbba48a7102c1"
+    },
+    {
+      "id": "REL-164",
+      "path": "santeria.md",
+      "sha256": "0d1ade95e3a721d1ff3460fa3dce9e2fb414f22d6891c73f572e4a484a75dfce"
+    },
+    {
+      "id": "REL-165",
+      "path": "santhal-tribal.md",
+      "sha256": "3826f6aba73a7b9d02523cc6697b97c192e47e4436dd2643b1d9cfc6ff74a659"
+    },
+    {
+      "id": "REL-166",
+      "path": "santo-daime.md",
+      "sha256": "c4ba75bbae38b047e3433c3e05d3c037fd914492d088e7ec2c96da9eed4552eb"
+    },
+    {
+      "id": "REL-167",
+      "path": "satanic-temple.md",
+      "sha256": "9bb7d9177827a82c2b787cbc83a60c1b691ce38b1f820be9bc41e9bd3c931249"
+    },
+    {
+      "id": "REL-168",
+      "path": "satanism.md",
+      "sha256": "596c35329cdc0bd7d12ae8d695e2043d652ca65e24cfa20da074b026a4bee7c6"
+    },
+    {
+      "id": "REL-169",
+      "path": "sathya-sai-baba-movement.md",
+      "sha256": "4bb6ac8f3fade14b00ff7e9d7329d7a9e0c88a6e170f2ea03629eedd30b7d0c6"
+    },
+    {
+      "id": "REL-170",
+      "path": "sathya-sai-baba.md",
+      "sha256": "e321796dbebb82c2f8081d8ecc4b247d46c7233a0f0c056d062071204057600b"
+    },
+    {
+      "id": "REL-171",
+      "path": "scientology.md",
+      "sha256": "cc2e0dd445d88a97640cea8de5e328ffef129f91a950d4579f781c8df67c6b7d"
+    },
+    {
+      "id": "REL-172",
+      "path": "secular-humanism.md",
+      "sha256": "7a29c6823001cf430c6a2125e27a07216c6661415d3135da7d885c83e8267231"
+    },
+    {
+      "id": "REL-173",
+      "path": "secular.md",
+      "sha256": "01faea92dbe39d789241b1275cacd71e8a182b0df0e802c7aae44b942f51e824"
+    },
+    {
+      "id": "REL-174",
+      "path": "seicho-no-ie.md",
+      "sha256": "5e21328d63693b44ea0faf7595cf3bc73b53088dad342d04b8ff93278a3eae7d"
+    },
+    {
+      "id": "REL-175",
+      "path": "sekai-kyusei-kyo.md",
+      "sha256": "2d43a8120d394cdf5cd2870c6f9edd538324eed412e4d44b7b4d04ac9a303214"
+    },
+    {
+      "id": "REL-176",
+      "path": "self-realization-fellowship.md",
+      "sha256": "9a4195b387c33dd950f6a6477d72580d086376254afcc84f2da345cec3967014"
+    },
+    {
+      "id": "REL-177",
+      "path": "serer.md",
+      "sha256": "dcc22318c5f33b37bc54c784129e41176edd7b15a3b6c2e0509d76ab6a1086ac"
+    },
+    {
+      "id": "REL-178",
+      "path": "shakers.md",
+      "sha256": "cc83c5de0cf1c0c7a14d560b2d52793b7e0c2da7bcc5938dbfe94f1b3dce743c"
+    },
+    {
+      "id": "REL-179",
+      "path": "shinnyo-en.md",
+      "sha256": "d3f70445de549e9ce82e8b6310e45f67d6cd52bfc6a5c6bd97c99c374ee0f51e"
+    },
+    {
+      "id": "REL-180",
+      "path": "shinto.md",
+      "sha256": "ddd68e772923dec667fca0fb3bb6748bb8803788843d5f39f9a5c44ef3a5e1c7"
+    },
+    {
+      "id": "REL-181",
+      "path": "sikhism.md",
+      "sha256": "25e1a192bb4cf2042efd96a8851290f1b219f9cf3470d4e3f23ba91a20402089"
+    },
+    {
+      "id": "REL-182",
+      "path": "slavic.md",
+      "sha256": "0aab473119d427e3e94e8d188d521580dd76426ac63d96aab50ee06c09b6f673"
+    },
+    {
+      "id": "REL-183",
+      "path": "srf.md",
+      "sha256": "4ea22bd88f3f9de02df8fb1f914f5881ae4d424b216003560e2b34bec210698e"
+    },
+    {
+      "id": "REL-184",
+      "path": "summit-lighthouse.md",
+      "sha256": "64ce547362e9bd54e1d7f9ceb3992ad01801bf438cdaaa97d61396d1946f2f4b"
+    },
+    {
+      "id": "REL-185",
+      "path": "swedenborgianism.md",
+      "sha256": "bcd7b8e6634a3e4e013184653e4283e6cda672529fad4aad31fca901d6f8c779"
+    },
+    {
+      "id": "REL-186",
+      "path": "swedenborgians.md",
+      "sha256": "98d8f3498f9f568c84d55a3d41cd15bf91ec72a874858c41dea81e4521416031"
+    },
+    {
+      "id": "REL-187",
+      "path": "taoism.md",
+      "sha256": "253e916a02a6a42522e42c84095a6a5f5ad482dfb16a77b24f4559545ed808ae"
+    },
+    {
+      "id": "REL-188",
+      "path": "temple-of-set.md",
+      "sha256": "347e4b304e9af42abf72a2f446fe2d313284fa87fd62a8ac9afcc0b9ccca4c16"
+    },
+    {
+      "id": "REL-189",
+      "path": "temple-of-the-vampire.md",
+      "sha256": "61cbde09e837195b4a30ceed5122650746d5bebc1f0239b2ddb2deeb714f1d05"
+    },
+    {
+      "id": "REL-190",
+      "path": "tenrikyo.md",
+      "sha256": "ba9880320abcc9df976dd71128596fe3ab33bc55edd89fdfcaa9365a8e93e948"
+    },
+    {
+      "id": "REL-191",
+      "path": "theistic-satanism.md",
+      "sha256": "fabdd186694266f6eff00b6e5bec4d47fc1664a6fbc47a3849752d10c800cd1e"
+    },
+    {
+      "id": "REL-192",
+      "path": "thelema.md",
+      "sha256": "61a810ae77944c7c430bc3e884f2aa2fdf69b3627fe4de2c23dd1d1e866fdf86"
+    },
+    {
+      "id": "REL-193",
+      "path": "theosophy.md",
+      "sha256": "3f0f96bc4266d61943bb9c0c1bb84556b00fa0881579530cac5390c6bc0f73ee"
+    },
+    {
+      "id": "REL-194",
+      "path": "toltec.md",
+      "sha256": "45397cad7c07ce6d4c4626397ba60582cd69cad8a3be09190d7e64d01821bb14"
+    },
+    {
+      "id": "REL-195",
+      "path": "transcendental-meditation.md",
+      "sha256": "af29ee225781ec0aa9d441b0c5c28438050e0610710849571df95e2bc9f4f989"
+    },
+    {
+      "id": "REL-196",
+      "path": "umbanda.md",
+      "sha256": "798f19c2492550e5c1fda44bcfa18437ed3b45fa37d25776e56ded0c78484c74"
+    },
+    {
+      "id": "REL-197",
+      "path": "uniao-do-vegetal.md",
+      "sha256": "5d987c66489a8a7dbb8053dd1bcc8b8e5b192ad293595489fa03a513ff041ce7"
+    },
+    {
+      "id": "REL-198",
+      "path": "unification-church.md",
+      "sha256": "c1cc8a352ed00136544b34edabe43a600541ba38b6259b31e1e66d0f2818cc0b"
+    },
+    {
+      "id": "REL-199",
+      "path": "unity-church.md",
+      "sha256": "9f8c2a500af9bcd4420d3a69d272eedf0831719319fd0f0aa42d1cc65ca42434"
+    },
+    {
+      "id": "REL-200",
+      "path": "universal-medicine.md",
+      "sha256": "8cd3c5f89d86331039fdee246f3cc70d6a0930783d40837fc7ce4ed08f5060a0"
+    },
+    {
+      "id": "REL-201",
+      "path": "vedanta-society.md",
+      "sha256": "5e59b725f468bd5e19b5e7cd48e67d668764498d55fbe9b80026cb79f7d89f31"
+    },
+    {
+      "id": "REL-202",
+      "path": "vodou.md",
+      "sha256": "7640f0a87ceec6c35f973123e8f37e9a7f5c7256cc283650fdc38f15a2ce90cc"
+    },
+    {
+      "id": "REL-203",
+      "path": "vodun.md",
+      "sha256": "5c90ad6abc925ba4719cc2dad9d316648d8da3a5cd48f757a2b7fcd91cda6141"
+    },
+    {
+      "id": "REL-204",
+      "path": "wicca-alexandrian.md",
+      "sha256": "39e72075227e46b13fef28415b4d15a58e711f4e44057b2358c20a0ddfdb25f0"
+    },
+    {
+      "id": "REL-205",
+      "path": "wicca-dianic.md",
+      "sha256": "0e96af1f220192b6a7947ae4b6596bc6d435bb6ed3e8cbdd4ac65483eb1cb102"
+    },
+    {
+      "id": "REL-206",
+      "path": "wicca-eclectic.md",
+      "sha256": "01b58bc92b3fb37245fed9845843924b54a768534ef335c7fe6fa3571da9b7e5"
+    },
+    {
+      "id": "REL-207",
+      "path": "wicca-gardnerian.md",
+      "sha256": "0c1e47ffbfa979a5aca23cd74d2f464a0b6acfe74256d224edeceaff9c36b9cc"
+    },
+    {
+      "id": "REL-208",
+      "path": "wicca.md",
+      "sha256": "d8661310e968d558e94ea0c26fd5c5a08f28c2a7a8e85df89a2ca97e34b94f77"
+    },
+    {
+      "id": "REL-209",
+      "path": "won-buddhism.md",
+      "sha256": "cc6dae63e2bb89c28697907627f008f85c4e4d45bc7d44d820521bce47f20ed4"
+    },
+    {
+      "id": "REL-210",
+      "path": "yali.md",
+      "sha256": "5b8a6f32bc2227340874e1a79285d57d261a86527c6df7f9d1e09c6310e5e523"
+    },
+    {
+      "id": "REL-211",
+      "path": "yazidism.md",
+      "sha256": "315cddbe0a2f6c4633e415b4c284c55534fcd688cca5e999f54d10f3192704ad"
+    },
+    {
+      "id": "REL-212",
+      "path": "yoruba.md",
+      "sha256": "7a2fb984c8fb343308cc84b8621e40d673dd44abc48e4ed485e7e6ee6ba23451"
+    },
+    {
+      "id": "REL-213",
+      "path": "zapotec.md",
+      "sha256": "d1d45e1c99f01f34e412abbb06af2fce17428391c57ccc97762fb96906fc8984"
+    },
+    {
+      "id": "REL-214",
+      "path": "zion-christian-church.md",
+      "sha256": "1cc77503aec9f58378e0b34dd786e34d8ef1c78c89f1607d8868f0aa84b1ce37"
+    },
+    {
+      "id": "REL-215",
+      "path": "zoroastrianism.md",
+      "sha256": "851bedb03f765e3e9005130f80a0395b95507f20a5caf95a75330befcc41a264"
+    },
+    {
+      "id": "REL-216",
+      "path": "zulu.md",
+      "sha256": "c591d260c5bf8f0d63fffe9728cebf1cfb6a74da21d23f36c5d0b6036e6c33cf"
+    }
+  ]
+}


### PR DESCRIPTION
## Superseded

This numeric `REL-001` registry proposal is closed without merging.

The design discussion established that religions and worldviews need stable mnemonic identifiers such as `REL-JW`, while branches and related movements remain separate `REL` records connected through typed relationships. Religious documents are subordinate addresses inside their religion, and persons, organizations, places, documents, and other concrete things use `OBJ`.

A replacement pull request will define the five-type connected-document model before any hashes are treated as authoritative.